### PR TITLE
47 Area VIP - contact card horizontal display for home page

### DIFF
--- a/blocks/contact-card/contact-card.css
+++ b/blocks/contact-card/contact-card.css
@@ -124,7 +124,7 @@
         width: 100%;
         max-height: none;
         display: grid;
-        grid-template-columns: auto 800px 400px auto;
+        grid-template-columns: auto 600px 360px auto;
     }
 
     .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card {
@@ -141,13 +141,22 @@
       display: block;
     }
 
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .title h3 {
+      margin-top: 0;
+      margin-bottom: 10px;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .title h3+p {
+      margin: 0;
+    }
+
     .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .telephone {
       display: flex;
       flex-basis: 50%;
       max-width: 50%;
       flex-direction: row;
       box-sizing: border-box;
-      margin-bottom: 45px;
+      line-height:normal;
     }
 
     .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .telephone::before {
@@ -165,5 +174,19 @@
       display: flex;
       align-items: flex-end;
       justify-content: center;
+      margin: 0;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .contact > div {
+      margin: 0;
+      padding: 0;
+      gap: 20px;
+    }
+}
+
+@media (min-width: 1200px) {
+      /* the home page version */
+      .section.info-vip.homepage.contact-card-container>.contact-card-wrapper {
+        grid-template-columns: auto 800px 400px auto;
     }
 }

--- a/blocks/contact-card/contact-card.css
+++ b/blocks/contact-card/contact-card.css
@@ -116,4 +116,54 @@
         background-color: var(--icon-primary-color);
         padding: 5px;
     }
+
+    /* the home page version */
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper {
+        grid-column: 1/5;
+        grid-row: 4/5;
+        width: 100%;
+        max-height: none;
+        display: grid;
+        grid-template-columns: auto 800px 400px auto;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card {
+      grid-column: 2/3;
+      padding: 28px 0 15px;
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .title {
+      flex-basis: 50%;
+      max-width: 50%;
+      margin-bottom: 25px;
+      display: block;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .telephone {
+      display: flex;
+      flex-basis: 50%;
+      max-width: 50%;
+      flex-direction: row;
+      box-sizing: border-box;
+      margin-bottom: 45px;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .telephone::before {
+      content: "\e90a";
+      font-family: Real-Madrid-New-Icons, sans-serif;
+      color: #999;
+      font-size: 45px;
+      border: 0;
+      background: none;
+    }
+
+    .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .contact {
+      flex-basis: 100%;
+      max-width: 100%;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+    }
 }

--- a/blocks/contact-card/contact-card.css
+++ b/blocks/contact-card/contact-card.css
@@ -162,7 +162,7 @@
     .section.info-vip.homepage.contact-card-container>.contact-card-wrapper .contact-card .telephone::before {
       content: "\e90a";
       font-family: Real-Madrid-New-Icons, sans-serif;
-      color: #999;
+      color:  var(--icon-primary-color);
       font-size: 45px;
       border: 0;
       background: none;


### PR DESCRIPTION
To render the contact card horizontally , you have to add `homepage` as a style to the section metadata:

![image](https://github.com/hlxsites/realmadrid/assets/37147400/1f1bf580-f9db-4208-9729-c9be1056de6c)


Fix #47

Test URLs:
- Before: homepage:  https://main--realmadrid--hlxsites.hlx.page/area-vip
 Non homepage: https://main--realmadrid--hlxsites.hlx.page/area-vip/partido-vip
- After: homepage:  https://47-contact-card-homepage--realmadrid--hlxsites.hlx.page/area-vip
 Non homepage: https://47-contact-card-homepage--realmadrid--hlxsites.hlx.page/area-vip/partido-vip
