### PR TITLE
fix: VIP Sections break when the URL contains an anchor

### DIFF
--- a/blocks/vip-sections/vip-sections.js
+++ b/blocks/vip-sections/vip-sections.js
@@ -74,8 +74,8 @@ export default async function decorate(block) {
 
   if (fragment) {
     // current vip section
-    const currentUrl = block.baseURI;
-    const excludedSectionPath = currentUrl.substring(currentUrl.lastIndexOf('/') + 1);
+    const pathSegments = new URL(block.baseURI).pathname.split('/');
+    const excludedSectionPath = pathSegments[pathSegments.length - 1];
 
     // turn into list
     const vipSections = transformToSectionsUnorderedList(fragment, excludedSectionPath);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #76

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/
- After: https://fix-76-vip-sections-filter-anchor-url--realmadrid--hlxsites.hlx.page/
