### PR TITLE
bug: fixing the header of the modal in area features

### DIFF
--- a/blocks/area-features/area-features.css
+++ b/blocks/area-features/area-features.css
@@ -94,7 +94,7 @@ main .area-features-wrapper {
   margin: 0;
 }
 
-.area-features .cards .modal .modal-content > .header {
+.area-features .cards .modal .modal-content > .modal-header {
   display: flex;
   align-items: center;
   gap: 18px;
@@ -102,7 +102,7 @@ main .area-features-wrapper {
   background: var(--background-color);
 }
 
-.area-features .header h3 {
+.area-features .modal-header h3 {
   font-size: 19px;
   margin: 0 0 6px;
   color: var(--text-color);

--- a/blocks/area-features/area-features.js
+++ b/blocks/area-features/area-features.js
@@ -75,7 +75,7 @@ function createModal(headingElements, content, hasIFrame) {
   <div class="modal-content-wrapper ${hasIFrame ? 'iframe-content' : ''}">
   <div class="modal-content">
   <button class="close" tabindex="0"></button>
-  <div class="header">
+  <div class="modal-header">
     ${[...headingElements].map((h) => h.outerHTML).join('')}
   </div>
     ${content.map((c) => c.outerHTML).join('')}


### PR DESCRIPTION
- the header has the same class as the header of the modal. Renamed the classname to modal-header

Fix #77

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/area-vip
- After: https://77-header-area-features--realmadrid--hlxsites.hlx.page/area-vip
