### PR TITLE
making the close button in modal dialog move to left for rtl languages

### DIFF
--- a/blocks/area-features/area-features.css
+++ b/blocks/area-features/area-features.css
@@ -140,6 +140,11 @@ main .area-features-wrapper {
   margin: 0;
 }
 
+[dir="rtl"] .area-features .cards .modal-content > .close {
+  left: 18px;
+  right: unset;
+}
+
 .area-features .cards .modal-content > .close::after {
   font-size: 17px;
   font-weight: 700;

--- a/blocks/area-features/area-features.css
+++ b/blocks/area-features/area-features.css
@@ -130,7 +130,7 @@ main .area-features-wrapper {
   width: 17px;
   height: 30px;
   top: 18px;
-  right: 18px;
+  inset-inline-end: 18px;
   position: absolute;
   cursor: pointer;
   background-color: unset;
@@ -138,11 +138,6 @@ main .area-features-wrapper {
   box-shadow: unset;
   padding: 0;
   margin: 0;
-}
-
-[dir="rtl"] .area-features .cards .modal-content > .close {
-  left: 18px;
-  right: unset;
 }
 
 .area-features .cards .modal-content > .close::after {


### PR DESCRIPTION
Fix #92

Open the modal dialog on clicking any features icon in info section and notice the location of the close (x) icon.

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/ar/vip-area
- After: https://issue-92--realmadrid--hlxsites.hlx.page/ar/vip-area
