### PR TITLE
110 - reading placeholders from correct language root

### DIFF
--- a/blocks/matches/matches.js
+++ b/blocks/matches/matches.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import { readBlockConfig, fetchPlaceholders } from '../../scripts/lib-franklin.js';
-import { getLocale } from '../../scripts/scripts.js';
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+import { getLocale, fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 // todo : make it configurable
 const API = {
   football: '/realmadridmastersite/matchesVIPFootball',
@@ -264,7 +264,7 @@ function createFilters(block, placeholders, months) {
 
 export default async function decorate(block) {
   const config = readBlockConfig(block);
-  const placeholders = await fetchPlaceholders();
+  const placeholders = await fetchLanguagePlaceholders();
   const { aemGqEndpoint, noMatches } = placeholders;
   const { sport } = config;
   const url = new URL(`${aemGqEndpoint}${API[sport.toLowerCase()]}`); // todo: add params fromDate endDate

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -265,6 +265,16 @@ export function getVipAreaIndexPath(url) {
   return `${url.origin}${VIP_AREA_LANGUAGE_HOME_PATH[language]}${VIP_AREA_INDEX}`;
 }
 
+export async function fetchLanguagePlaceholders() {
+  const currentLanguage = getLanguage();
+  let prefix = `/${currentLanguage}`;
+  if (language === 'es') {
+    prefix = 'default';
+  }
+  const placeholders = await fetchPlaceholders(prefix);
+  return placeholders;
+}
+
 /**
  * Adds a child div that wraps the blocks below 'merge-blocks-desktop' section and moves the class
  * to the new child.


### PR DESCRIPTION

Fix #110

Test URLs:
- Before: https://main--realmadrid-hlxsites.hlx.page/area-vip
- After: https://issue-110--realmadrid-hlxsites.hlx.page/hi/vip-area
