### PR TITLE
feat: [tour] default content, removed button and standardized text color

### DIFF
--- a/sites/blocks/columns/full-columns.css
+++ b/sites/blocks/columns/full-columns.css
@@ -24,7 +24,7 @@
 .columns.full .text {
   font-weight: 400;
   line-height: 24px;
-  color: #444;
+  color: var(--text-color);
   margin: 0 0 25px;
 }
 

--- a/sites/blocks/columns/organize-visit.css
+++ b/sites/blocks/columns/organize-visit.css
@@ -66,13 +66,13 @@ body.tour .section.section-organize-visit .default-content-wrapper {
   flex-basis: max-content;
   line-height: 22px;
   font-weight: 400;
-  color: #222;
+  color: var(--text-color);
 }
 
 .columns.organize-visit .text-wrapper p {
   line-height: 22px;
   margin: 0;
-  color: #222;
+  color: var(--text-color);
 }
 
 @media (min-width: 900px) {

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -363,8 +363,20 @@ body.tour main .section-organize-visit {
 }
 
 body.tour main .section .default-content-wrapper p {
-  color: #444;
+  color: var(--text-color);
   margin: 0;
+}
+
+body.tour main .section .default-content-wrapper p:last-of-type.button-container a {
+  text-transform: none;
+  font-size: var(--body-font-size-s);
+  color: var(--text-color);
+  background-color: unset;
+  font-weight: 500;
+  border: unset;
+  padding: 30px 0 0;
+  text-decoration: underline;
+  box-shadow: unset;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
@@ -373,6 +385,7 @@ body.tour main h2 {
   font-weight: 400;
   margin-bottom: 3px;
   margin-top: 0;
+  font-size: var(--heading-font-size-m);
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
@@ -456,7 +469,7 @@ body.tour.tour-detail main .main-section ul li::marker {
 }
 
 body.tour.tour-detail main .main-section ul li {
-  color: #444;
+  color: var(--text-color);
 }
 
 body.tour.tour-detail main .main-section blockquote::before,


### PR DESCRIPTION
This PR:

- removes the button style for the last link in tour's default content wrapper section
- unifies the text colours of the blocks and default content to var(--text-color) aka #43526E

Fix #119 

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
- After: https://119-tour-link-defaultcontent--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
