### PR TITLE
134 - add basic styling for documentation pages

### DIFF
--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -205,8 +205,11 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'));
-  loadFooter(doc.querySelector('footer'));
+  /* Don't show header and footer in the authoring guide */
+  if (toClassName(getMetadata('template')) !== 'documentation') {
+    loadHeader(doc.querySelector('header'));
+    loadFooter(doc.querySelector('footer'));
+  }
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   addFavIcon(`${window.hlx.codeBasePath}/styles/favicon.svg`);

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -570,6 +570,20 @@ body.vip-faq main .section div p, body.vip-faq main .section div ul {
 }
 
 /** STYLES FOR AUTHORING GUIDE **/
+/* stylelint-disable-next-line no-descending-specificity */
+body.documentation h2 {
+  margin-top: 100px;
+  font-weight: 400;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+body.documentation h3 {
+  margin-top: 60px;
+  font-weight: 400;
+  font-size: 1.1em;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
 body.documentation img {
   margin-left: auto;
   margin-right: auto;
@@ -577,15 +591,4 @@ body.documentation img {
   margin-top: 50px;
   display: block;
   border:solid 1px #444;
-}
-
-body.documentation h2 {
-  margin-top: 100px;
-  font-weight: 400;
-}
-
-body.documentation h3 {
-  margin-top: 60px;
-  font-weight: 400;
-  font-size: 1.1em;
 }

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -568,3 +568,24 @@ body.vip-faq main .section div p, body.vip-faq main .section div ul {
     margin-top:  40px 0 0 0;
   }
 }
+
+/** STYLES FOR AUTHORING GUIDE **/
+body.documentation img {
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 50px;
+  margin-top: 50px;
+  display: block;
+  border:solid 1px #444;
+}
+
+body.documentation h2 {
+  margin-top: 100px;
+  font-weight: 400;
+}
+
+body.documentation h3 {
+  margin-top: 60px;
+  font-weight: 400;
+  font-size: 1.1em;
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #134

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/authoring-guide/areavip
- After: https://134-documentation--realmadrid--hlxsites.hlx.page/authoring-guide/areavip
