### PR TITLE
bug: improving accessibility score in LH

### DIFF
--- a/sites/blocks/footer/footer.css
+++ b/sites/blocks/footer/footer.css
@@ -117,8 +117,8 @@ footer {
 .footer-mobile-apps {
   text-align: center;
   vertical-align: center;
-  padding: 20px 0;
-  border-top: 1px solid #E6E9ED;
+  margin: 0;
+  padding: 0;
 }
 
 .footer-mobile-apps li {
@@ -126,7 +126,8 @@ footer {
   display: inline-block;
 }
 
-.footer-mobile-apps h3, .footer-mobile-apps h4 {
+.footer-main-section > h3, .footer-main-section > h4 {
+  text-align: center;
   font-family: RMNeue, Helvetica, Arial, sans-serif;
   font-weight: normal;
   font-size: 14px;
@@ -134,11 +135,13 @@ footer {
   margin: 0;
 }
 
-.footer-mobile-apps h3 {
+.footer-main-section > h3 {
   color: #8C95A6;
+  border-top: 1px solid #E6E9ED;
+  padding: 20px 0 0;
 }
 
-.footer-mobile-apps h4 {
+.footer-main-section > h4 {
   color: #0E2145;
 }
 

--- a/sites/blocks/footer/footer.css
+++ b/sites/blocks/footer/footer.css
@@ -136,7 +136,6 @@ footer {
 }
 
 .footer-main-section > h3 {
-  color: #8C95A6;
   border-top: 1px solid #E6E9ED;
   padding: 20px 0 0;
 }

--- a/sites/blocks/footer/footer.js
+++ b/sites/blocks/footer/footer.js
@@ -74,8 +74,8 @@ export default async function decorate(block) {
     const li = document.createElement('li');
     mainSponsors.append(li);
     li.appendChild(document.createRange().createContextualFragment(`
-      <a href="${item.url}" alt="${item.title}">
-        <img src="${item.logo._publishUrl}">
+      <a href="${item.url}">
+        <img src="${item.logo._publishUrl}" alt="${item.title}">
       </a>
     `));
   });
@@ -86,8 +86,8 @@ export default async function decorate(block) {
     const li = document.createElement('li');
     otherSponsors.append(li);
     li.appendChild(document.createRange().createContextualFragment(`
-      <a href="${item.url}" alt="${item.title}">
-        <img src="${item.logo._publishUrl}">
+      <a href="${item.url}">
+        <img src="${item.logo._publishUrl}" alt="${item.title}">
       </a>
     `));
   });

--- a/sites/blocks/footer/footer.js
+++ b/sites/blocks/footer/footer.js
@@ -52,11 +52,11 @@ export default async function decorate(block) {
 
   const mobileApps = document.createElement('ul');
   mobileApps.classList.add('footer-mobile-apps');
-  mainSection.append(mobileApps);
-  mobileApps.appendChild(document.createRange().createContextualFragment(`
+  mainSection.append(document.createRange().createContextualFragment(`
     <h3>${footerConfig.mobileAPPLinks.title}</h3>
     <h4>${footerConfig.mobileAPPLinks.subtitle}</h4>
   `));
+  mainSection.append(mobileApps);
   footerConfig.mobileAPPLinks.appLinks.forEach((item) => {
     const li = document.createElement('li');
     mobileApps.append(li);

--- a/sites/blocks/header/header.js
+++ b/sites/blocks/header/header.js
@@ -18,13 +18,13 @@ export default async function decorate(block) {
 
   const sponsorIcons = data.data.header.items[0].sponsors.map((sponsor) => (
     // eslint-disable-next-line no-underscore-dangle
-    `<img src='${sponsor.logo._publishUrl}' class="header-sponsor-icon"/>`
+    `<img src='${sponsor.logo._publishUrl}' class="header-sponsor-icon" alt="${sponsor.title}"/>`
   )).join('');
   const { sponsorsLink } = data.data.header.items[0];
 
   const logo = data.data.header.items[0].additionalLogos[0];
   // eslint-disable-next-line no-underscore-dangle
-  const logoImg = logo && logo.image ? `<img src='${logo.image._publishUrl}' style="width: 40px; height: 40px; margin-left: 16px"/>` : '';
+  const logoImg = logo && logo.image ? `<img src='${logo.image._publishUrl}' style="width: 40px; height: 40px; margin-left: 16px" alt="${logo.title}"/>` : '';
   const { login } = await fetchLanguagePlaceholders();
   block.appendChild(document.createRange().createContextualFragment(`
     <div style="flex: 1 0 auto; display: flex; flex-direction: row; justify-content: space-between; align-items: center">

--- a/sites/blocks/matches/matches.css
+++ b/sites/blocks/matches/matches.css
@@ -185,7 +185,6 @@ main > .matches-container h2 {
   font-size: 0.813rem;;
   font-weight: 300;
   flex: 0 0 100%;
-  color: #808080;
   box-sizing: border-box;
   order: 6;
 }

--- a/sites/blocks/matches/matches.js
+++ b/sites/blocks/matches/matches.js
@@ -153,7 +153,7 @@ const renderMatch = (placeholders) => (match) => {
   const time = new Date(dateTime);
   const month = monthFormat.format(time);
   const content = `
-  <input type="checkbox" />
+  <input aria-label="add to calendar" type="checkbox" />
   <div class="calendar-info">
     <a href="#">${pricesAndSales}</a>
     <span>${addToCalendar}</span>


### PR DESCRIPTION
Fix #139

- fixed color contrast
- moved `h3`/`h4` elements that were child of `ul`. `ul` should only have `li` as its direct child.
- added `alt` attribute to images correctly. In some cases it was added to `a`
- added aria-label to form elements.

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/area-vip
- After: https://lhs--realmadrid--hlxsites.hlx.page/sites/area-vip
