### PR TITLE
banner-carousel block redesign + section style classes removed

### DIFF
--- a/sites/blocks/banner-carousel/banner-carousel.css
+++ b/sites/blocks/banner-carousel/banner-carousel.css
@@ -22,46 +22,44 @@ body main .section.banner-carousel-container {
   min-width: 100%;
 }
 
-.banner-carousel .carousel-slide h2 {
+.banner-carousel .carousel-slide .text-container {
   position: absolute;
-  top: 175px;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   z-index: 1;
-  color: var(--background-color);
-  text-align: center;
-  font-size: var(--heading-font-size-xl);
+  align-content: space-evenly;
 }
 
-.banner-carousel .carousel-slide h3 {
-  position: absolute;
-  top: 150px;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
+.banner-carousel .carousel-slide .text-container h2 {
+  position: relative;
+  opacity: 0.9;
+  text-shadow: 0 2px 4px rgb(0 0 0 / 26%);
+  text-transform: uppercase;
   z-index: 1;
   color: var(--background-color);
   text-align: center;
   font-size: var(--heading-font-size-xs);
   font-weight: 400;
+  width: 100%;
 }
 
-.banner-carousel .carousel-slide p {
-  margin: 0;
+.banner-carousel .carousel-slide .text-container h2 strong {
+  font-size: var(--heading-font-size-xl);
+  font-weight: 400;
+  display: block;
 }
 
-.banner-carousel .carousel-slide p:last-of-type {
-  position: absolute;
-  bottom: 200px;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
+.banner-carousel .carousel-slide .text-container p {
+  position: relative;
   z-index: 1;
   color: var(--background-color);
   max-width: 300px;
   text-align: center;
   padding: 0 15px;
+  width: 100%;
 }
 
 .banner-carousel .carousel-slide picture::before {
@@ -81,19 +79,11 @@ body main .section.banner-carousel-container {
   height: 100%;
 }
 
-.banner-carousel .carousel-slide .pic-desktop {
-  display: none;
-}
-
-.banner-carousel .carousel-slide .pic-mobile {
-  display: block;
-}
-
-.banner-carousel .carousel-slide .pic-mobile img {
+.banner-carousel .carousel-slide picture img {
   object-fit: cover;
   min-width: 100%;
   height: 100%;
-  width: auto;
+  position: absolute;
 }
 
 .banner-carousel .control-container .image-pagination {
@@ -164,21 +154,6 @@ body main .section.banner-carousel-container {
   display: none;
 }
 
-@media screen and (orientation: landscape) and  (max-height: 430px) {
-  .banner-carousel .carousel-slide h2 {
-    top: 90px;
-  }
-
-  .banner-carousel .carousel-slide h3 {
-    top: 70px;
-  }
-
-  .banner-carousel .carousel-slide p:last-of-type{
-    bottom: 60px;
-    max-width: 500px;
-  }
-}
-
 @media screen and (min-width: 990px) {
   body main .section .banner-carousel-wrapper {
     margin: 0;
@@ -189,36 +164,15 @@ body main .section.banner-carousel-container {
     height: 550px;
   }
 
-  .banner-carousel .carousel-slide .pic-desktop {
-    display: block;
-  }
-
-  .banner-carousel .carousel-slide .pic-desktop img{
-    width: auto;
-    min-width: 100%;
+  .banner-carousel .carousel-slide .picture img {
     max-width: 100%;
-    height: 100%;
-    object-fit: cover;
   }
 
-  .banner-carousel .carousel-slide .pic-mobile {
-    display: none;
-  }
-
-  .banner-carousel .carousel-slide h2 {
-    top: 165px;
-  }
-
-  .banner-carousel .carousel-slide h3 {
-    top: 140px;
-  }
-
-  .banner-carousel .carousel-slide p:last-of-type{
-    bottom: 100px;
+  .banner-carousel .carousel-slide p:last-of-type {
     max-width: 750px;
   }
 
-  .banner-carousel .control-container .prev, .banner-carousel .control-container .next{
+  .banner-carousel .control-container .prev, .banner-carousel .control-container .next {
     height: 30px;
     width: 30px;
     opacity: 0.5;
@@ -234,31 +188,26 @@ body main .section.banner-carousel-container {
 /*
 banner carousel - single banner option styling
  */
-.banner-carousel.single-banner .carousel-slide h2,
-.banner-carousel.single-banner .carousel-slide h3 {
-  inset-inline-start: 20px;
-  top: auto;
-  text-align: start;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1; /* number of lines to show */
+.banner-carousel.single-banner .carousel-slide .text-container {
+  align-content: unset;
 }
 
-.banner-carousel.single-banner .carousel-slide h3 {
-  bottom: 105px;
+.banner-carousel.single-banner .carousel-slide .text-container h2 {
+  margin-top: auto;
+  margin-left: 20px;
+  text-align: start;
+  width: auto;
+  margin-bottom: 35px;
+  font-weight: 500;
+  opacity: 1;
   font-size: var(--heading-font-size-l);
   line-height: var(--heading-font-size-l);
-  max-height: calc(var(--heading-font-size-l) * 1); /* fallback */
 }
 
-.banner-carousel.single-banner .carousel-slide h2 {
-  bottom: 35px;
+.banner-carousel.single-banner .carousel-slide .text-container h2 strong {
   font-size: 70px;
   line-height: 70px;
-  max-height: 70px; /* fallback */
+  font-weight: 500;
 }
 
 .banner-carousel.single-banner .control-container {
@@ -270,10 +219,7 @@ banner carousel - single banner option styling
 }
 
 @media screen and (min-width: 990px) {
-  .banner-carousel.single-banner .carousel-slide h3,
-  .banner-carousel.single-banner .carousel-slide h2 {
-    width: var(--wrapper-width);
-    margin: 0 auto;
-    inset-inline-start: 0;
+  .banner-carousel.single-banner .carousel-slide .text-container h2 {
+    margin-left: unset;
   }
 }

--- a/sites/blocks/banner-carousel/banner-carousel.css
+++ b/sites/blocks/banner-carousel/banner-carousel.css
@@ -1,7 +1,3 @@
-body main .section.banner-carousel-container {
-  padding: 0;
-}
-
 .banner-carousel.block {
   position: relative;
   overflow: hidden;
@@ -55,6 +51,7 @@ body main .section.banner-carousel-container {
 .banner-carousel .carousel-slide .text-container p {
   position: relative;
   z-index: 1;
+  font-size: var(--body-font-size-xs);
   color: var(--background-color);
   max-width: 300px;
   text-align: center;
@@ -168,10 +165,6 @@ body main .section.banner-carousel-container {
     max-width: 100%;
   }
 
-  .banner-carousel .carousel-slide p:last-of-type {
-    max-width: 750px;
-  }
-
   .banner-carousel .control-container .prev, .banner-carousel .control-container .next {
     height: 30px;
     width: 30px;
@@ -182,6 +175,16 @@ body main .section.banner-carousel-container {
     opacity: 0.8;
     cursor: pointer;
     transition: opacity 0.5s;
+  }
+
+  .banner-carousel .carousel-slide .text-container p {
+    font-size: var(--body-font-size-s);
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .banner-carousel .carousel-slide p:last-of-type {
+    max-width: 750px;
   }
 }
 
@@ -219,7 +222,32 @@ banner carousel - single banner option styling
 }
 
 @media screen and (min-width: 990px) {
+  body main .section.banner-carousel-container .default-content-wrapper {
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 50px;
+    width: 650px;
+    margin: 0 auto;
+  }
+
+  body main .section.banner-carousel-container .default-content-wrapper p{
+    font-weight: 400;
+  }
+
   .banner-carousel.single-banner .carousel-slide .text-container h2 {
     margin-left: unset;
   }
+}
+
+body main .section.banner-carousel-container {
+  padding: 0;
+}
+
+body main .section.banner-carousel-container .default-content-wrapper {
+  padding: 20px;
+  width: auto;
+}
+
+body main .section.banner-carousel-container .default-content-wrapper p{
+  font-weight: bold;
 }

--- a/sites/blocks/banner-carousel/banner-carousel.css
+++ b/sites/blocks/banner-carousel/banner-carousel.css
@@ -1,3 +1,16 @@
+body main .section.banner-carousel-container {
+  padding: 0;
+}
+
+.section.banner-carousel-container .default-content-wrapper {
+  padding: 20px;
+  width: auto;
+}
+
+.section.banner-carousel-container .default-content-wrapper p{
+  font-weight: bold;
+}
+
 .banner-carousel.block {
   position: relative;
   overflow: hidden;
@@ -152,7 +165,7 @@
 }
 
 @media screen and (min-width: 990px) {
-  body main .section .banner-carousel-wrapper {
+  .section .banner-carousel-wrapper {
     margin: 0;
     width: 100%;
   }
@@ -222,7 +235,7 @@ banner carousel - single banner option styling
 }
 
 @media screen and (min-width: 990px) {
-  body main .section.banner-carousel-container .default-content-wrapper {
+  .section.banner-carousel-container .default-content-wrapper {
     padding-left: 0;
     padding-right: 0;
     padding-top: 50px;
@@ -230,24 +243,11 @@ banner carousel - single banner option styling
     margin: 0 auto;
   }
 
-  body main .section.banner-carousel-container .default-content-wrapper p{
+  .section.banner-carousel-container .default-content-wrapper p{
     font-weight: 400;
   }
 
   .banner-carousel.single-banner .carousel-slide .text-container h2 {
     margin-left: unset;
   }
-}
-
-body main .section.banner-carousel-container {
-  padding: 0;
-}
-
-body main .section.banner-carousel-container .default-content-wrapper {
-  padding: 20px;
-  width: auto;
-}
-
-body main .section.banner-carousel-container .default-content-wrapper p{
-  font-weight: bold;
 }

--- a/sites/blocks/banner-carousel/banner-carousel.css
+++ b/sites/blocks/banner-carousel/banner-carousel.css
@@ -61,6 +61,7 @@ body main .section.banner-carousel-container .default-content-wrapper p {
   display: block;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .banner-carousel .carousel-slide .text-container p {
   position: relative;
   z-index: 1;

--- a/sites/blocks/banner-carousel/banner-carousel.css
+++ b/sites/blocks/banner-carousel/banner-carousel.css
@@ -2,12 +2,12 @@ body main .section.banner-carousel-container {
   padding: 0;
 }
 
-.section.banner-carousel-container .default-content-wrapper {
+body main .section.banner-carousel-container .default-content-wrapper {
   padding: 20px;
   width: auto;
 }
 
-.section.banner-carousel-container .default-content-wrapper p{
+body main .section.banner-carousel-container .default-content-wrapper p {
   font-weight: bold;
 }
 
@@ -235,7 +235,7 @@ banner carousel - single banner option styling
 }
 
 @media screen and (min-width: 990px) {
-  .section.banner-carousel-container .default-content-wrapper {
+ body main .section.banner-carousel-container .default-content-wrapper {
     padding-left: 0;
     padding-right: 0;
     padding-top: 50px;
@@ -243,11 +243,12 @@ banner carousel - single banner option styling
     margin: 0 auto;
   }
 
-  .section.banner-carousel-container .default-content-wrapper p{
+ body main .section.banner-carousel-container .default-content-wrapper p{
     font-weight: 400;
   }
 
   .banner-carousel.single-banner .carousel-slide .text-container h2 {
     margin-left: unset;
+    width: 650px;
   }
 }

--- a/sites/blocks/banner-carousel/banner-carousel.js
+++ b/sites/blocks/banner-carousel/banner-carousel.js
@@ -143,19 +143,17 @@ function initializeScroll(block, slidesNo) {
 }
 
 export default function decorate(block) {
-  const cols = [...block.firstElementChild.children];
+  const cols = [...block.children];
   let entries = '';
+  // create carousel section
+  const carousel = document.createElement('div');
   cols.forEach((slide, index) => {
     slide.classList.add('carousel-slide');
-    const images = slide.querySelectorAll('picture');
-    if (images.length === 2) {
-      images[0].classList.add('pic-desktop');
-      images[1].classList.add('pic-mobile');
-    }
-    slide.prepend(images[0]);
-    slide.prepend(images[1]);
+    slide.lastElementChild.classList.add('text-container');
+    carousel.append(slide);
     entries += `<div data-slide="${index + 1}" class="indicator ${index === 0 ? 'active' : ''}"></div>`;
   });
+  // create indicators section
   const indicatorsHTML = `
 <div class="control-container">
     <div class="prev hide">&#10094</div>
@@ -164,6 +162,6 @@ export default function decorate(block) {
     </div>
     <div class="next hide">&#10095</div>
   </div>`;
-  block.innerHTML += indicatorsHTML;
+  block.innerHTML = carousel.outerHTML + indicatorsHTML;
   initializeScroll(block, cols.length);
 }

--- a/sites/blocks/banner-carousel/banner-carousel.js
+++ b/sites/blocks/banner-carousel/banner-carousel.js
@@ -1,4 +1,5 @@
 import { bindSwipeToElement } from '../../scripts/scripts.js';
+import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 
 function nextElement(el, selector) {
   if (selector) {
@@ -148,6 +149,11 @@ export default function decorate(block) {
   // create carousel section
   const carousel = document.createElement('div');
   cols.forEach((slide, index) => {
+    const bannerPic = slide.querySelector('picture');
+    const bannerImg = bannerPic.querySelector('img');
+    const optimizedPic = createOptimizedPicture(bannerImg.src, bannerImg.alt, false, [{ media: '(min-width: 600px)', width: '2000' }, { width: '1200' }]);
+    slide.prepend(optimizedPic);
+    bannerPic.remove();
     slide.classList.add('carousel-slide');
     slide.lastElementChild.classList.add('text-container');
     carousel.append(slide);

--- a/sites/blocks/columns/organize-visit.css
+++ b/sites/blocks/columns/organize-visit.css
@@ -66,6 +66,7 @@ body.tour .section.section-organize-visit .default-content-wrapper {
   flex-basis: max-content;
   line-height: 22px;
   font-weight: 400;
+  font-size: var(--body-font-size-xs);
   color: var(--text-color);
 }
 

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -153,6 +153,18 @@ function buildFAQPage(main) {
 }
 
 /**
+ * Decorates the main content container to match tour detail page styling.
+ * the main content container is the one which contains text only and no other blocks.
+ * @param {Element} main The main element
+ */
+function buildTourDetailContent(main) {
+  main.parentElement.classList.add('tour');
+  const contentWrappers = main.querySelectorAll(':scope > div');
+  [...contentWrappers].filter((contentWrapper) => !contentWrapper.querySelector('div'))
+    .map((contentWrapper) => contentWrapper.classList.add('main-content'));
+}
+
+/**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
@@ -169,7 +181,7 @@ function buildAutoBlocks(main) {
         buildHeroBlock(main);
       }
       if (template === 'tour-detail') {
-        main.parentElement.classList.add('tour');
+        buildTourDetailContent(main);
       }
     }
   } catch (error) {

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -366,7 +366,7 @@ export function bindSwipeToElement(el) {
 
   el.addEventListener('touchstart', (e) => {
     touchstartX = e.changedTouches[0].screenX;
-  });
+  }, { passive: true });
 
   el.addEventListener('touchend', (e) => {
     touchendX = e.changedTouches[0].screenX;
@@ -376,7 +376,7 @@ export function bindSwipeToElement(el) {
     if (touchendX > touchstartX) {
       el.dispatchEvent(new CustomEvent('swipe-LTR'));
     }
-  });
+  }, { passive: true });
 }
 
 async function loadPage() {

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -168,6 +168,9 @@ function buildAutoBlocks(main) {
       if (template === 'area-vip') {
         buildHeroBlock(main);
       }
+      if (template === 'tour-detail') {
+        main.parentElement.classList.add('tour');
+      }
     }
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -425,12 +425,12 @@ body.tour main .merge-blocks-desktop {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-body.tour.tour-detail main [class='section'] .default-content-wrapper h2 {
+body.tour.tour-detail main .main-content .default-content-wrapper h2 {
   font-size: var(--heading-font-size-l);
   margin-bottom: 0;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
+body.tour.tour-detail main .main-content .default-content-wrapper h3 {
   font-size: var(--heading-font-size-s);
   font-weight: 300;
   margin-bottom: 13px;
@@ -439,12 +439,12 @@ body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
   color: var(--heading-color);
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote {
+body.tour.tour-detail main .main-content .default-content-wrapper blockquote {
   padding: 0 28px;
   margin: 0;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote p {
+body.tour.tour-detail main .main-content .default-content-wrapper blockquote p {
   font-size: var(--body-font-size-m);
   font-weight: 300;
   font-style: italic;
@@ -452,25 +452,25 @@ body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote
   color: #64809b;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper p:first-of-type {
+body.tour.tour-detail main .main-content .default-content-wrapper p:first-of-type {
   margin-bottom: 20px;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper ul {
+body.tour.tour-detail main .main-content .default-content-wrapper ul {
   margin-left: 0;
   padding-left: 24px;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper ul li::marker {
+body.tour.tour-detail main .main-content .default-content-wrapper ul li::marker {
   color: #d8dfe6;
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper ul li {
+body.tour.tour-detail main .main-content .default-content-wrapper ul li {
   color: var(--text-color);
 }
 
-body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote::before,
-body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote::after {
+body.tour.tour-detail main .main-content .default-content-wrapper blockquote::before,
+body.tour.tour-detail main .main-content .default-content-wrapper blockquote::after {
   content: '';
   width: 50px;
   height: 1px;
@@ -480,46 +480,46 @@ body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote
 }
 
 @media (min-width: 990px) {
-  body.tour.tour-detail main [class='section']:first-of-type {
+  body.tour.tour-detail main .main-content:first-of-type {
     width: 930px;
     margin: 0 auto;
     padding: 0;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper .default-content-wrapper {
+  body.tour.tour-detail main .main-content .default-content-wrapper {
     width: auto;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper h2 {
+  body.tour.tour-detail main .main-content .default-content-wrapper h2 {
     font-size: var(--heading-font-size-xxxl);
     line-height: 65px;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
+  body.tour.tour-detail main .main-content .default-content-wrapper h3 {
     margin-top: 70px;
     font-size: var(--heading-font-size-m);
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper p,
-  body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
+  body.tour.tour-detail main .main-content .default-content-wrapper p,
+  body.tour.tour-detail main .main-content .default-content-wrapper h3 {
     padding-left: 290px;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper p,
-  body.tour.tour-detail main [class='section'] .default-content-wrapper li {
+  body.tour.tour-detail main .main-content .default-content-wrapper p,
+  body.tour.tour-detail main .main-content .default-content-wrapper li {
     font-size: 17px;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote {
+  body.tour.tour-detail main .main-content .default-content-wrapper blockquote {
     padding-left: 431px;
     padding-right: 135px;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote p {
+  body.tour.tour-detail main .main-content .default-content-wrapper blockquote p {
     padding: 0;
   }
 
-  body.tour.tour-detail main [class='section'] .default-content-wrapper ul {
+  body.tour.tour-detail main .main-content .default-content-wrapper ul {
     padding-left: 314px;
   }
 }

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -329,8 +329,9 @@ main .section > div {
 }
 
 /* TOUR STYLES */
-body.tour main p {
-  font-size: var(--body-font-size-s);
+body.tour main p,
+body.tour main li {
+  font-size: var(--body-font-size-xs);
 }
 
 body.tour main .section {
@@ -347,10 +348,6 @@ body.tour main .section p {
 body.tour .section .default-content-wrapper {
   padding-bottom: 61px;
   padding-top: 54px;
-}
-
-body.tour .section.padding-bottom-small .default-content-wrapper {
-  padding-bottom: 28px;
 }
 
 body.tour .default-content-wrapper ul {
@@ -370,7 +367,7 @@ body.tour main .section .default-content-wrapper p {
 
 body.tour main .section .default-content-wrapper p:last-of-type.button-container a {
   text-transform: none;
-  font-size: var(--body-font-size-s);
+  font-size: var(--body-font-size-xs);
   color: var(--text-color);
   background-color: unset;
   font-weight: 500;
@@ -402,7 +399,6 @@ body.tour main .merge-blocks-desktop {
 
 @media (min-width: 990px) {
   body.tour .section .default-content-wrapper {
-    padding-bottom: 89px;
     padding-top: 83px;
   }
 
@@ -411,7 +407,7 @@ body.tour main .merge-blocks-desktop {
     width: var(--wrapper-width);
     margin: 0 auto;
     column-gap: 26px;
-    padding-bottom: 96px;
+    padding-bottom: 76px;
   }
 
   body.tour .merge-blocks-desktop .columns-wrapper{
@@ -429,12 +425,12 @@ body.tour main .merge-blocks-desktop {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-body.tour.tour-detail main .main-section h2 {
+body.tour.tour-detail main [class='section'] .default-content-wrapper h2 {
   font-size: var(--heading-font-size-l);
   margin-bottom: 0;
 }
 
-body.tour.tour-detail main .main-section h3 {
+body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
   font-size: var(--heading-font-size-s);
   font-weight: 300;
   margin-bottom: 13px;
@@ -443,12 +439,12 @@ body.tour.tour-detail main .main-section h3 {
   color: var(--heading-color);
 }
 
-body.tour.tour-detail main .main-section blockquote {
+body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote {
   padding: 0 28px;
   margin: 0;
 }
 
-body.tour.tour-detail main .main-section blockquote p {
+body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote p {
   font-size: var(--body-font-size-m);
   font-weight: 300;
   font-style: italic;
@@ -456,25 +452,25 @@ body.tour.tour-detail main .main-section blockquote p {
   color: #64809b;
 }
 
-body.tour.tour-detail main .main-section p:first-of-type {
+body.tour.tour-detail main [class='section'] .default-content-wrapper p:first-of-type {
   margin-bottom: 20px;
 }
 
-body.tour.tour-detail main .main-section ul {
+body.tour.tour-detail main [class='section'] .default-content-wrapper ul {
   margin-left: 0;
   padding-left: 24px;
 }
 
-body.tour.tour-detail main .main-section ul li::marker {
+body.tour.tour-detail main [class='section'] .default-content-wrapper ul li::marker {
   color: #d8dfe6;
 }
 
-body.tour.tour-detail main .main-section ul li {
+body.tour.tour-detail main [class='section'] .default-content-wrapper ul li {
   color: var(--text-color);
 }
 
-body.tour.tour-detail main .main-section blockquote::before,
-body.tour.tour-detail main .main-section blockquote::after {
+body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote::before,
+body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote::after {
   content: '';
   width: 50px;
   height: 1px;
@@ -484,41 +480,46 @@ body.tour.tour-detail main .main-section blockquote::after {
 }
 
 @media (min-width: 990px) {
-  body.tour.tour-detail main .main-section {
+  body.tour.tour-detail main [class='section']:first-of-type {
     width: 930px;
     margin: 0 auto;
     padding: 0;
   }
 
-  body.tour.tour-detail main .main-section .default-content-wrapper {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper .default-content-wrapper {
     width: auto;
   }
 
-  body.tour.tour-detail main .main-section h2 {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper h2 {
     font-size: var(--heading-font-size-xxxl);
     line-height: 65px;
   }
 
-  body.tour.tour-detail main .main-section h3 {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
     margin-top: 70px;
     font-size: var(--heading-font-size-m);
   }
 
-  body.tour.tour-detail main .main-section p,
-  body.tour.tour-detail main .main-section h3 {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper p,
+  body.tour.tour-detail main [class='section'] .default-content-wrapper h3 {
     padding-left: 290px;
   }
 
-  body.tour.tour-detail main .main-section blockquote {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper p,
+  body.tour.tour-detail main [class='section'] .default-content-wrapper li {
+    font-size: 17px;
+  }
+
+  body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote {
     padding-left: 431px;
     padding-right: 135px;
   }
 
-  body.tour.tour-detail main .main-section blockquote p {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper blockquote p {
     padding: 0;
   }
 
-  body.tour.tour-detail main .main-section ul {
+  body.tour.tour-detail main [class='section'] .default-content-wrapper ul {
     padding-left: 314px;
   }
 }


### PR DESCRIPTION
This PR contains the redesign of the banner-carousel block, which can be created as a two coulmns table where as a first element you need to put the image and as a second element the text.

sharepoint page:
https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B069DCEFA-C06B-49A4-8432-E8F64B6CF4A6%7D&file=tour-bernabeu.docx&action=default&mobileredirect=true

This PR contains also text harmonization to 15px and the removal of section's styling like "padding-bottom-small" or "main-section"

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/en/tour-bernabeu
- After: https://fix-banner-carousel-redesign--realmadrid--hlxsites.hlx.page/sites/en/tour-bernabeu
