### PR TITLE
feat: [vip] added swipe support to carousel

### DIFF
--- a/sites/blocks/carousel/carousel.css
+++ b/sites/blocks/carousel/carousel.css
@@ -3,10 +3,13 @@
 }
 
 main .section > .carousel-wrapper {
-  margin: 0 0 0 -10px;
   width: 100vw;
   max-width: unset;
   overflow: hidden;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-inline-start: -10px;
+  margin-inline-end: 0;
 }
 
 main .carousel > .carousel-pics-container {

--- a/sites/blocks/carousel/carousel.css
+++ b/sites/blocks/carousel/carousel.css
@@ -1,6 +1,10 @@
+.carousel.block {
+  float: left;
+}
+
 main .section > .carousel-wrapper {
-  margin: 0;
-  width: 100%;
+  margin: 0 0 0 -10px;
+  width: 100vw;
   max-width: unset;
   overflow: hidden;
 }
@@ -46,6 +50,11 @@ main .carousel .carousel-buttons-container {
 }
 
 @media (min-width: 990px) {
+  main .section > .carousel-wrapper {
+    width: 100%;
+    margin: 0;
+  }
+
   main .carousel > .carousel-pics-container .pic-container {
     margin-right: 4px;
     width: 480px;

--- a/sites/blocks/carousel/carousel.css
+++ b/sites/blocks/carousel/carousel.css
@@ -1,5 +1,5 @@
 .carousel.block {
-  float: left;
+  min-height: 235px;
 }
 
 main .section > .carousel-wrapper {

--- a/sites/blocks/carousel/carousel.js
+++ b/sites/blocks/carousel/carousel.js
@@ -1,4 +1,5 @@
 import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
+import { bindSwipeToElement } from '../../scripts/scripts.js';
 
 function createButtons() {
   const divButtons = document.createElement('div');
@@ -89,6 +90,22 @@ export default function decorate(block) {
     }
   });
 
+  bindSwipeToElement(block);
+  block.addEventListener('swipe-RTL', () => {
+    window.clearInterval(carouselInterval);
+    if (currentPic < maxShift) {
+      currentPic += 1;
+      showPic(currentPic, picWidth, carouselPicContainer);
+    }
+  });
+  block.addEventListener('swipe-LTR', () => {
+    window.clearInterval(carouselInterval);
+    if (currentPic >= 1) {
+      currentPic -= 1;
+      showPic(currentPic, picWidth, carouselPicContainer);
+    }
+  });
+
   // Add listeners on images to be pupup showed in a bigger size after click
   // Get all elements with class 'pic-container'
   const photos = document.getElementsByClassName('pic-container');
@@ -96,6 +113,7 @@ export default function decorate(block) {
   // Loop over all the photo elements
   Array.from(photos).forEach((photo) => {
     // Add click event listener to each photo
+    // eslint-disable-next-line func-names
     photo.addEventListener('click', function () {
       // Create main wrap div and add classes and attributes to it
       const wrapDiv = document.createElement('div');

--- a/sites/styles/styles.css
+++ b/sites/styles/styles.css
@@ -184,9 +184,7 @@ body.area-vip h2 {
   color: var(--heading-color);
   text-transform: uppercase;
   margin-bottom: 21px;
-  margin-inline-start: 10px;
   padding-bottom: 5px;
-  width: var(--section-heading-width);
   border-right: 4px solid transparent;
   border-bottom: 4px solid var(--heading-border-color);
 }
@@ -293,6 +291,12 @@ main .section > div {
   body.area-vip .section.section.info-vip > .default-content-wrapper:first-of-type h2 {
     font-size: var(--heading-font-size-m);
     width: auto;
+  }
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  body.area-vip h2 {
+    width: var(--section-heading-width);
+    margin-inline-start: 10px;
   }
 
   .section.info-vip {


### PR DESCRIPTION
This PR adds swipe support to carousel block and includes some style enhancemntes in mobile view

Fix #132 

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/en/vip-area/matchday-hospitality/silver-club-227
- After: https://132-add-slider-to-vip-area-carousel--realmadrid--hlxsites.hlx.page/sites/en/vip-area/matchday-hospitality/silver-club-227
