### PR TITLE
Added table block to help authoring guide creation

### DIFF
--- a/sites/blocks/table/table.css
+++ b/sites/blocks/table/table.css
@@ -1,0 +1,51 @@
+.table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table table {
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  font-size: var(--body-font-size-xs);
+}
+
+@media (min-width: 600px) {
+  .table table {
+    font-size: var(--body-font-size-s);
+  }
+}
+
+@media (min-width: 900px) {
+  .table table {
+    font-size: var(--body-font-size-m);
+  }
+}
+
+.table table thead tr {
+  border-top: 2px solid;
+  border-bottom: 2px solid;
+}
+
+.table table tbody tr {
+  border-bottom: 1px solid;
+}
+
+.table table th {
+  font-weight: 700;
+}
+
+.table table th, .table table td {
+  padding: 8px 16px;
+  text-align: left;
+}
+
+/* striped variant */
+.table.striped tbody tr:nth-child(odd) {
+  background-color: var(--overlay-background-color);
+}
+
+/* bordered variant */
+.table.bordered table th, .table.bordered table td {
+  border: 1px solid;
+}

--- a/sites/blocks/table/table.css
+++ b/sites/blocks/table/table.css
@@ -40,6 +40,24 @@
   text-align: left;
 }
 
+/* no heading variant */
+.table.no-heading table thead {
+  border-right: 1px solid;
+}
+
+.table.no-heading table thead tr {
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+}
+
+.table.no-heading table th {
+  font-weight: 400;
+}
+
+.table.no-heading table p {
+  margin: 0;
+}
+
 /* striped variant */
 .table.striped tbody tr:nth-child(odd) {
   background-color: var(--overlay-background-color);

--- a/sites/blocks/table/table.js
+++ b/sites/blocks/table/table.js
@@ -1,0 +1,30 @@
+/*
+ * Table Block
+ * Recreate a table
+ * https://www.hlx.live/developer/block-collection/table
+ */
+
+function buildCell(rowIndex) {
+  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
+  if (!rowIndex) cell.setAttribute('scope', 'col');
+  return cell;
+}
+
+export default async function decorate(block) {
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const tbody = document.createElement('tbody');
+  table.append(thead, tbody);
+  [...block.children].forEach((child, i) => {
+    const row = document.createElement('tr');
+    if (i) tbody.append(row);
+    else thead.append(row);
+    [...child.children].forEach((col) => {
+      const cell = buildCell(i);
+      cell.innerHTML = col.innerHTML;
+      row.append(cell);
+    });
+  });
+  block.innerHTML = '';
+  block.append(table);
+}


### PR DESCRIPTION
I've introduced the table block, contained in the block collection, to help us create some block examples in the authoring guide:

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/authoring-guide/tourbernabeu#banner-carousel
- After: https://feat-table-block--realmadrid--hlxsites.hlx.page/authoring-guide/tourbernabeu#banner-carousel
