### PR TITLE
Introducing new variable scrollAmount which calculated based on the f…

### DIFF
--- a/sites/blocks/columns/columns.js
+++ b/sites/blocks/columns/columns.js
@@ -125,14 +125,20 @@ export default function decorate(block) {
     const swipeThreshold = 100;
     bindSwipeToElementWithForce(tabsWrapper);
     tabsWrapper.addEventListener('swipe-RTL', (e) => {
-      if (e.detail.force > swipeThreshold && targetIndex < tabs.length - 1) {
-        targetIndex += 1;
+      // Calculate how many tabs to scroll, round up to nearest whole number
+      const scrollAmount = Math.ceil(e.detail.force / swipeThreshold);
+      // If we're not at the last slide...
+      if (targetIndex + scrollAmount < tabs.length) {
+        targetIndex += scrollAmount;
         smoothScrollToSlide(tabsWrapper, tabs, targetIndex);
       }
     });
     tabsWrapper.addEventListener('swipe-LTR', (e) => {
-      if (e.detail.force > swipeThreshold && targetIndex > 0) {
-        targetIndex -= 1;
+      // Calculate how many tabs to scroll, round up to nearest whole number
+      const scrollAmount = Math.ceil(e.detail.force / swipeThreshold);
+      // If we're not at the first slide...
+      if (targetIndex - scrollAmount >= 0) {
+        targetIndex -= scrollAmount;
         smoothScrollToSlide(tabsWrapper, tabs, targetIndex);
       }
     });


### PR DESCRIPTION
Introducing new variable scrollAmount which calculated based on the force of the swipe and use it to increase or decrease the targetIndex of the tab:

Fix [#165](https://github.com/hlxsites/realmadrid/issues/165)

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/tour/es/fragments/faq
- After: https://165-better-support-force-swipe-ios--realmadrid--hlxsites.hlx.page/tour/es/fragments/faq
