### PR TITLE
167 tour hero Support for Bold, Italic, Underline formatting and mulitline text

### DIFF
--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -121,7 +121,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
 }
 
 /* promo text */
-.hero-tour.block .content .promo {
+.hero-tour.block .content .promo, .hero-tour.block .content .promo > p {
   margin: 0 auto 0.813rem;
   padding: 0;
   font-family: var(--body-font-family);
@@ -250,12 +250,21 @@ body.tour .section.hero-tour-container .hero-tour.block {
   }
 
   /* promo text */
-  .hero-tour.block .content .promo {
+  .hero-tour.block .content .promo , .hero-tour.block .content .promo > p {
     font-size: 1.25rem;
-    margin-bottom: 4.6875rem;
     font-weight: 400;
     max-width: none;
   }
+
+  .hero-tour.block .content .promo > p {
+    margin-bottom: 2rem;
+  }
+
+  .hero-tour.block .content .promo  {
+    margin-bottom: 4.6875rem;
+  }
+
+
 
   .hero-tour.block .content .promo strong {
     display: inline;

--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -264,8 +264,6 @@ body.tour .section.hero-tour-container .hero-tour.block {
     margin-bottom: 4.6875rem;
   }
 
-
-
   .hero-tour.block .content .promo strong {
     display: inline;
     font-weight: 600;

--- a/sites/blocks/hero-tour/hero-tour.js
+++ b/sites/blocks/hero-tour/hero-tour.js
@@ -3,13 +3,13 @@ import { readBlockConfig, loadBlock, decorateIcons } from '../../scripts/lib-fra
 export default async function decorate(block) {
   // get config entries
   const cfg = readBlockConfig(block);
-
   const {
-    pretitle, title, promo, desktop, navigation, mobile,
+    pretitle, title, desktop, navigation, mobile,
   } = cfg;
-  const promoTitle = cfg['promo-title'];
   const tourCategory = cfg['tour-category'];
   const tourSubCategory = cfg['tour-sub-category'];
+  // for promo we keep the original formatting
+  const promo = [...block.querySelectorAll(':scope > div')].filter((entry) => entry.children[0].innerText.trim().toLowerCase() === 'promo');
 
   // create basic dom structure
   const dom = document.createRange().createContextualFragment(`
@@ -80,17 +80,10 @@ export default async function decorate(block) {
   }
 
   // if promo text and/or promo title is defined
-  if (promo || promoTitle) {
+  if (promo[0]) {
     const promoElem = document.createElement('p');
     promoElem.classList.add('promo');
-    if (promoTitle) {
-      const strong = document.createElement('strong');
-      strong.textContent = promoTitle;
-      promoElem.append(strong);
-    }
-    if (promo) {
-      promoElem.append(` ${promo}`);
-    }
+    promoElem.innerHTML = promo[0].children[1].innerHTML;
     contentWrapper.append(promoElem);
   }
 


### PR DESCRIPTION
Changes:
- block property `Promo Title` no longer required
- Bold/italic/underline/paragraphs formating of `promo` in word gets preserved
- In desktop view, each paragraph is rendered on a separate line
- in mobile view, addtionally each bold text gets rendered on a seprate line, normal text font gets smaller.

Fix #167

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
- After: https://167-tour-hero-promo--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
