### PR TITLE
136 swipping tour navigation and sub categories

### DIFF
--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -78,14 +78,6 @@ body.tour .section.hero-tour-container .hero-tour.block {
   -ms-overflow-style: none;
 }
 
-.hero-tour.block .content .navcontainer nav a:first-child {
-  margin-left: 20px;
-}
-
-.hero-tour.block .content .navcontainer nav a:last-child {
-  margin-right: 20px;
-}
-
 .hero-tour.block .content .navcontainer nav::-webkit-scrollbar {
   display:none;
 }
@@ -114,6 +106,14 @@ body.tour .section.hero-tour-container .hero-tour.block {
   text-transform: uppercase;
   text-decoration: none;
   vertical-align: top;
+}
+
+.hero-tour.block .content .navcontainer nav a:first-child {
+  margin-left: 20px;
+}
+
+.hero-tour.block .content .navcontainer nav a:last-child {
+  margin-right: 20px;
 }
 
 /* when we are on the page itself */

--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -75,7 +75,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
 /* navigation entries */
 .hero-tour.block .content .navcontainer nav a {
   font-size: 0.875rem;
-  color: #fff;
+  color: var(--background-color);
   height: 2rem;
   margin-right: 1rem;
   flex-shrink: 0;
@@ -91,7 +91,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
   line-height: 0.8;
   padding: 0 0.75rem;
   border-radius: 1rem;
-  border: solid 0.06rem #fff;
+  border: solid 0.06rem var(--background-color);
   background-color: rgba(0 0 0 / 50%);
   text-transform: uppercase;
   text-decoration: none;
@@ -157,7 +157,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
   font-weight: 400;
   line-height: 1.11;
   letter-spacing: 0.07rem;
-  color: #fff;
+  color: var(--background-color);
   text-transform: uppercase;
 }
 
@@ -337,7 +337,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
   padding: 0 1.875rem 1.5625rem;
   box-sizing: border-box;
   display: block;
-  background-color: #fff;
+  background-color: var(--background-color);
   border-bottom-right-radius: 1rem;
   border-bottom-left-radius: 1rem;
   text-decoration: underline;
@@ -455,7 +455,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
 
 /* ticket details block */
 .hero-tour.block .ticket-card-list.hero .ticket-detail {
-  background-color: #fff;
+  background-color: var(--background-color);
   box-sizing: border-box;
   padding: 1.25rem 1.875rem 0.5rem;
 }

--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -256,6 +256,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
   }
 
   /* navigation */
+  
   /* .hero-tour.block .content .navcontainer nav {
     margin: 0 auto;
   }
@@ -370,7 +371,8 @@ body.tour .section.hero-tour-container .hero-tour.block {
 
 /* stylelint-disable-next-line no-descending-specificity */
 .hero-tour.block .ticket-card-list.hero > ul > li > a::after  {
-  content: url('../../icons/arrow-right.svg');
+  content: '';
+  background-image: url('../../icons/arrow-right.svg');
   filter: invert(24%) sepia(95%) saturate(4099%) hue-rotate(200deg) brightness(93%) contrast(101%);
   width: 13px;
   height: 13px;
@@ -775,7 +777,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
   position: relative;
   margin-left: auto;
   margin-right: auto;
-  padding: 0 0.9375rem;
+  padding: 0;
   box-sizing: border-box;
 }
 
@@ -795,17 +797,30 @@ body.tour .section.hero-tour-container .hero-tour.block {
 /* -- the sub category ticket cards (no breakpoints ) -- */
 
 /* the list of sub category tickets */
-.hero-tour.block .ticket-card-list.hero.sub ul {
+
+.hero-tour.block .ticket-card-list.hero.sub > ul {
   position: relative;
-  width: 100%;
   height: 100%;
   z-index: 1;
   display: flex;
   list-style-type: none;
   transition-property: transform;
   box-sizing: content-box;
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
+  scrollbar-width:none;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none;
+  overflow-x: auto;
+  overflow-y: hidden;
+  width:max-content;
+  max-width: 100%;
+  flex-wrap: nowrap;
+}
+
+
+.hero-tour.block .ticket-card-list.hero.sub > ul::-webkit-scrollbar  {
+  display:none;
 }
 
 /* li is the root element of a card */
@@ -825,7 +840,8 @@ body.tour .section.hero-tour-container .hero-tour.block {
   font-size: 1rem;
   line-height: 1;
   background : var(--background-color);
-  margin-right: 15px;
+  margin-right: 8px;
+  margin-left: 8px;
 }
 
 /* the combo image */
@@ -941,4 +957,5 @@ body.tour .section.hero-tour-container .hero-tour.block {
   font-size: 0.8125rem;
   line-height: 1;
   color: #0067d1;
+  padding: 0 0.875rem;
 }

--- a/sites/blocks/hero-tour/hero-tour.css
+++ b/sites/blocks/hero-tour/hero-tour.css
@@ -51,7 +51,7 @@ body.tour .section.hero-tour-container .hero-tour.block {
 .hero-tour.block .content .navcontainer {
   width: auto;
   height: 2rem;
-  margin: 1.25rem 1.25rem 1.875rem;
+  margin: 1.25rem 0 1.875rem;
   position: relative;
   padding: 0;
   z-index: 1;
@@ -59,7 +59,9 @@ body.tour .section.hero-tour-container .hero-tour.block {
 
 .hero-tour.block .content .navcontainer nav {
   position: relative;
-  width: 100%;
+  margin: 0 auto;
+  width:max-content;
+  max-width:100%;
   height: 100%;
   padding: 0;
   font-size: 0;
@@ -70,6 +72,22 @@ body.tour .section.hero-tour-container .hero-tour.block {
   transition-property: transform;
   transition-timing-function: ease-out;
   box-sizing: content-box;
+  overflow: auto;
+  scrollbar-width:none;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none;
+}
+
+.hero-tour.block .content .navcontainer nav a:first-child {
+  margin-left: 20px;
+}
+
+.hero-tour.block .content .navcontainer nav a:last-child {
+  margin-right: 20px;
+}
+
+.hero-tour.block .content .navcontainer nav::-webkit-scrollbar {
+  display:none;
 }
 
 /* navigation entries */
@@ -238,10 +256,10 @@ body.tour .section.hero-tour-container .hero-tour.block {
   }
 
   /* navigation */
-  .hero-tour.block .content .navcontainer nav {
-    justify-content: center;
-    margin: 1.875rem 0;
+  /* .hero-tour.block .content .navcontainer nav {
+    margin: 0 auto;
   }
+  */ 
 
   /* navigation entries */
   .hero-tour.block .content .navcontainer nav a {

--- a/sites/blocks/hero-tour/hero-tour.js
+++ b/sites/blocks/hero-tour/hero-tour.js
@@ -1,4 +1,5 @@
 import { readBlockConfig, loadBlock, decorateIcons } from '../../scripts/lib-franklin.js';
+import { fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   // get config entries
@@ -10,6 +11,13 @@ export default async function decorate(block) {
   const promoTitle = cfg['promo-title'];
   const tourCategory = cfg['tour-category'];
   const tourSubCategory = cfg['tour-sub-category'];
+
+  // get placeholders (non-existing values are undefined)
+  const placeholders = await fetchLanguagePlaceholders();
+  const {
+    youCanAlsoChoose = 'También podéis elegir',
+    combinedVisits = 'VISITAS COMBINADAS',
+  } = placeholders;
 
   // create basic dom structure
   const dom = document.createRange().createContextualFragment(`
@@ -133,8 +141,8 @@ export default async function decorate(block) {
     const subCatContainer = document.createRange().createContextualFragment(`
     <div class='sub-wrapper'>
       <h2 class='sub-cat-title'>
-        <span class='sub-cat-subtitle'>También podéis elegir</span>
-        VISITAS COMBINADAS
+        <span class='sub-cat-subtitle'>${youCanAlsoChoose}</span>
+        ${combinedVisits}
       </h2>
       <div class='ticket-card-list hero sub' data-block-name='ticket-card-list' >
         <div>

--- a/sites/blocks/hero-tour/hero-tour.js
+++ b/sites/blocks/hero-tour/hero-tour.js
@@ -1,26 +1,5 @@
 import { readBlockConfig, loadBlock, decorateIcons } from '../../scripts/lib-franklin.js';
-import { bindSwipeToElementWithForce, fetchLanguagePlaceholders } from '../../scripts/scripts.js';
-
-let swipeDistance = 0;
-
-function slideTourNav(navContainer, force) {
-  const direction = force < 0 ? 'left' : 'right';
-  const absForce = Math.abs(force);
-  const { left } = navContainer.firstElementChild.getBoundingClientRect();
-  const { right } = navContainer.lastElementChild.getBoundingClientRect();
-  const maxLeftScroll = right < window.innerWidth ? 0 : right - window.innerWidth;
-  const maxRightScroll = left > 0 ? 0 : Math.abs(left);
-  // if completely visible
-  if (left >= 0 && right <= window.innerWidth) swipeDistance = 0;
-  if (direction === 'left') {
-    swipeDistance -= maxLeftScroll > absForce ? absForce : maxLeftScroll;
-  } else {
-    swipeDistance += maxRightScroll > absForce ? absForce : maxRightScroll;
-  }
-  // do the transform
-  const transform = `transform: translate3d(${swipeDistance}px, 0px, 0px); transition-duration: 300ms;`;
-  navContainer.style.cssText = transform;
-}
+import { fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   // get config entries
@@ -82,20 +61,6 @@ export default async function decorate(block) {
       divNavContainer.append(navElem);
       contentWrapper.append(divNavContainer);
 
-      // add events
-      bindSwipeToElementWithForce(navElem);
-      navElem.addEventListener('swipe-RTL', (e) => {
-        slideTourNav(navElem, e.detail.force * -1);
-      });
-
-      navElem.addEventListener('swipe-LTR', (e) => {
-        slideTourNav(navElem, e.detail.force);
-      });
-
-      window.addEventListener('resize', () => {
-        slideTourNav(navElem, 0);
-      });
-
       // get the navigation table from the fragment
       const navEntries = document.createRange().createContextualFragment(await resp.text()).querySelector('.navigation');
       // add entries
@@ -150,6 +115,8 @@ export default async function decorate(block) {
 
   block.textContent = '';
   block.append(dom);
+
+  block.querySelector('a.selected').scrollIntoView();
 
   // what main tour categories are offered
   if (tourCategory) {

--- a/sites/blocks/hero-tour/hero-tour.js
+++ b/sites/blocks/hero-tour/hero-tour.js
@@ -116,8 +116,6 @@ export default async function decorate(block) {
   block.textContent = '';
   block.append(dom);
 
-  block.querySelector('a.selected').scrollIntoView();
-
   // what main tour categories are offered
   if (tourCategory) {
     const ticketCardListBlock = document.createRange().createContextualFragment(`

--- a/sites/blocks/related-tours/related-tours.css
+++ b/sites/blocks/related-tours/related-tours.css
@@ -70,7 +70,7 @@ main .section.related-tours-container .related-tours-wrapper {
 @media (min-width: 600px) {
   /* the gradient background starts scrolling */
   body.tour main .section.related-tours-container {
-    padding: 4.6875rem 0.625rem 4.063rem;
+    padding: 4.6875rem 0 4.063rem;
     background-attachment: local;
   }
 

--- a/sites/blocks/related-tours/related-tours.css
+++ b/sites/blocks/related-tours/related-tours.css
@@ -14,7 +14,6 @@ body.tour main .section.related-tours-container {
 /* the wrapper has restricted width and padding */
 main .section.related-tours-container .related-tours-wrapper {
   max-width: 1200px;
-  padding-left: 1.5625rem;
   box-sizing: border-box;
   width: initial;
 }
@@ -28,6 +27,7 @@ main .section.related-tours-container .related-tours-wrapper {
   letter-spacing: -0.53px;
   color: var(--background-color);
   margin-bottom: 1.875rem;
+  padding-left: 1.5625rem;
 }
 
 /* related tours subtitle */
@@ -270,6 +270,7 @@ main .section.related-tours-container .related-tours-wrapper {
 }
 
 .related-tours.block .ticket-card-list.related .info-link::after  {
+  content: '';
   background-image: url('../../icons/arrow-right.svg');
   filter: invert(24%) sepia(95%) saturate(4099%) hue-rotate(200deg) brightness(93%) contrast(101%);
   display: inline-flex;
@@ -383,7 +384,7 @@ main .section.related-tours-container .related-tours-wrapper {
   height: 13.75rem;
   overflow: hidden;
   position: relative;
-  padding: 0 0.9375rem;
+  padding: 0;
   max-width: 100vw;
   margin: 0 auto;
   box-sizing: border-box;
@@ -399,6 +400,21 @@ main .section.related-tours-container .related-tours-wrapper {
   align-items: flex-start;
   list-style: none;
   height: 100%;
+  margin: 0 auto;
+  width: max-content;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width:none;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none;
+  max-width: 100%;
+  flex-wrap:nowrap;
+  justify-content: initial;
+  min-width: 100%;
+}
+
+.related-tours.block .ticket-card-list.related.sub > ul::-webkit-scrollbar {
+  display: none;
 }
 
 /* the sub category list li */
@@ -411,14 +427,14 @@ main .section.related-tours-container .related-tours-wrapper {
   flex-wrap: wrap;
   align-items: flex-start;
   color: #000;
-  overflow: hidden;
   box-sizing: border-box;
   letter-spacing: 0;
   padding: 1.5625rem 0;
   word-spacing: 0;
   border-radius: 1rem;
   background: var(--background-color);
-  margin: 0 15px 0 0;
+  margin: 0 8px ;
+  min-width: 12.5rem;
 }
 
 /* the sub category image */
@@ -485,6 +501,7 @@ main .section.related-tours-container .related-tours-wrapper {
   .related-tours.block .ticket-card-list.related.sub > ul > li {
     width: 9.375rem;
     flex-flow: wrap;
+    min-width: 9.375rem;
   }
 
   /* the buy button */

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -286,6 +286,13 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
+  // scroll to active tour navigation entry
+  if (toClassName(getMetadata('template')) === 'tour') {
+    const heroTourBlockNav = document.querySelector('.hero-tour.block .navcontainer > nav');
+    const selected = heroTourBlockNav.querySelector('a.selected');
+    heroTourBlockNav.scrollLeft = selected.offsetLeft - 20;
+  }
+
   /* Don't show header and footer in the authoring guide */
   if (toClassName(getMetadata('template')) !== 'documentation') {
     loadHeader(doc.querySelector('header'));


### PR DESCRIPTION
- added swipping for the tour navigation in the hero-tour block
- added swipping for the sub category tickets (combo tickets) in the hero-tour block
- added swipping for the sub category tickets (combo tickets) in the related-tours block
- added placeholders for the sub category title/subtitle in related tours block
- other small fixes/improvements

Fix #136

Test URLs:
- Before:
Tour Navigation Swipping / Combo Tickets swipping in hero tour block:
https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu/colegios
Combo Tickets swipping in related tours block
https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu/colegios/classic
- After: 
Tour Navigation Swipping / Combo Tickets swipping in hero tour block:
https://136-tour-hero-swipe--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu/colegios
Combo Tickets swipping in related tours block
https://136-tour-hero-swipe--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu/colegios/classic
