### PR TITLE
129 use h1 title for FAQ page if defined

### DIFF
--- a/sites/blocks/content-header/content-header.js
+++ b/sites/blocks/content-header/content-header.js
@@ -9,7 +9,10 @@ async function getTitle(path) {
 
 export default function decorate(block) {
   block.textContent = '';
-  const title = document.querySelector('title')?.innerText;
+  // if there is an h1 in main text take it as the main title otherwise page title
+  const hasH1Title = document.querySelector('main h1:first-child');
+  const title = hasH1Title ? (hasH1Title.remove(), hasH1Title.innerText) : document.querySelector('title')?.innerText;
+
   // init header DOM structure
   const dom = document.createRange().createContextualFragment(`
     <h1>${title}</h1>


### PR DESCRIPTION
- Uses first H1 title in main content as title for content header if defined
- otherwise falls back to page title 

Fix #129

Test URLs:

- Before: 
Page with a H1 title in content:
https://main--realmadrid--hlxsites.hlx.page/sites/hi/vip-area/faqs
Page with no H1 title in content:
https://main--realmadrid--hlxsites.hlx.page/sites/area-vip/faq
- After: 
Page with a H1 title in content:
https://129-faq-title--realmadrid--hlxsites.hlx.page/sites/hi/vip-area/faqs
Page with no H1 title in content:
https://129-faq-title--realmadrid--hlxsites.hlx.page/sites/area-vip/faq
