### PR TITLE
176 fixed arrow icon in footer, added check if tour nav exists

### DIFF
--- a/sites/blocks/columns/organize-visit.css
+++ b/sites/blocks/columns/organize-visit.css
@@ -18,8 +18,9 @@ body.tour .section.section-organize-visit .default-content-wrapper {
   color: #6b6b6b;
 }
 
-.columns.organize-visit .icon.icon-open-link::before {
-  content: url('../../icons/open-link.svg');
+.columns.organize-visit .visit-box:last-child a[href*="MuseoRealMadrid" ]::after {
+  content: '';
+  background-image: url('../../icons/open-link.svg');
   display: inline-flex;
   filter: invert(24%) sepia(95%) saturate(4099%) hue-rotate(200deg) brightness(93%) contrast(101%);
   width: 11px;

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -289,8 +289,10 @@ async function loadLazy(doc) {
   // scroll to active tour navigation entry
   if (toClassName(getMetadata('template')) === 'tour') {
     const heroTourBlockNav = document.querySelector('.hero-tour.block .navcontainer > nav');
-    const selected = heroTourBlockNav.querySelector('a.selected');
-    heroTourBlockNav.scrollLeft = selected.offsetLeft - 20;
+    if (heroTourBlockNav) {
+      const selected = heroTourBlockNav.querySelector('a.selected');
+      heroTourBlockNav.scrollLeft = selected.offsetLeft - 20;
+    }
   }
 
   /* Don't show header and footer in the authoring guide */


### PR DESCRIPTION
- fixed arrow icon in 'Organze your visit' footer section
- removed icon reference in `sites/tour-bernabeu/en/fragments/organize-your-visit.docx` and `sites/tour-bernabeu/fragments/organize-your-visit.docx`
- added check if tour nav exists before trying to scroll active nav into view
- 
Fix #176 

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
- After: https://176-arrow-icon--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
