### PR TITLE
fix: data layer variables

### DIFF
--- a/sites/scripts/delayed.js
+++ b/sites/scripts/delayed.js
@@ -37,7 +37,8 @@ function getPageLoadTrackingPayload() {
   trackingPath = trackingPath.replace(`${DOCROOT}/`, '');
 
   const trackingPathArray = trackingPath.split('/');
-  const trackingPageName = trackingPathArray.length > 1 ? ['realmadrid', currentSection].concat(trackingPathArray.slice(1)) : ['realmadrid', currentSection].concat(trackingPathArray);
+  const trackingPageName = trackingPathArray.length > 1 ? ['realmadrid', currentSection].concat(trackingPathArray.slice(1))
+    : ['realmadrid'].concat(trackingPathArray);
 
   const webPageDetails = {
     pageName: trackingPageName.join(':'),
@@ -54,6 +55,13 @@ function getPageLoadTrackingPayload() {
     country: currentLanguage,
     cms: 'aem_franklin',
   };
+
+  // Replace dashes with underscores in values for specific properties
+  ['pageName', 'pageSection', 'pageLevel1', 'pageLevel2', 'pageLevel3', 'pageType'].forEach((key) => {
+    if (webPageDetails[key]) {
+      webPageDetails[key] = webPageDetails[key].replace(/-/g, '_');
+    }
+  });
 
   // Get the pageName we want to track. e.g. realmadrid:tour:colegios:classic
   // We try to use the path to the page in Spanish.

--- a/sites/scripts/delayed.js
+++ b/sites/scripts/delayed.js
@@ -36,19 +36,20 @@ function getPageLoadTrackingPayload() {
   // get rid of the prefix
   trackingPath = trackingPath.replace(`${DOCROOT}/`, '');
 
+  // Get the pageName we want to track. e.g. realmadrid:tour:colegios:classic
   const trackingPathArray = trackingPath.split('/');
   const trackingPageName = trackingPathArray.length > 1 ? ['realmadrid', currentSection].concat(trackingPathArray.slice(1))
-    : ['realmadrid'].concat(trackingPathArray);
+    : ['realmadrid', currentSection];
 
   const webPageDetails = {
     pageName: trackingPageName.join(':'),
     pageTitle: getMetadata('og:title'),
     pageURL: window.location.href,
     pageSection: currentSection,
-    pageLevel1: trackingPageName.length > 1 ? trackingPageName[1] : '',
-    pageLevel2: trackingPageName.length > 2 ? trackingPageName[2] : '',
-    pageLevel3: trackingPageName.length > 3 ? trackingPageName[3] : '',
-    pageLevel4: trackingPageName.length > 4 ? trackingPageName[4] : '',
+    pageLevel1: trackingPageName.length > 2 ? trackingPageName[2] : '',
+    pageLevel2: trackingPageName.length > 3 ? trackingPageName[3] : '',
+    pageLevel3: trackingPageName.length > 4 ? trackingPageName[4] : '',
+    pageLevel4: trackingPageName.length > 5 ? trackingPageName[5] : '',
     pageType: currentSection,
     previousPageURL: document.referrer,
     pageLang: currentLanguage,
@@ -63,8 +64,6 @@ function getPageLoadTrackingPayload() {
     }
   });
 
-  // Get the pageName we want to track. e.g. realmadrid:tour:colegios:classic
-  // We try to use the path to the page in Spanish.
   window.rm = window.rm || {};
   const userInfo = window.rm.user;
 


### PR DESCRIPTION
Based on customer validation: https://adobe-dx-support.slack.com/archives/C04L2G6GF8X/p1688481906054629?thread_ts=1682323232.901519&cid=C04L2G6GF8X

> The value of the levels (pageLevel1, pageLevel2...) is not correct. pageLevel1 has the same value as pageSection and this should not be the case. Example: https://main--realmadrid--hlxsites.hlx.live/sites/fr/tour-bernabeu/ecoles/guidee, the correct values would be: pageSection "tour", pageLevel1 = "colegios", pageLevel2 = "guiada", pageLevel3 = ""

> Variable values must use the character "_" instead of "-" to separate values.

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.live/sites/fr/tour-bernabeu/ecoles/guidee
- After: https://fix-data-layer-variables--realmadrid--hlxsites.hlx.live/sites/fr/tour-bernabeu/ecoles/guidee
