### PR TITLE
190 404 redirect

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,7 +21,7 @@
       };
       const segments = window.location.pathname.split('/');
       const locale = segments[1] && LANG_LOCALE[segments[1]] ? LANG_LOCALE[segments[1]] : 'es-ES';
-      window.location.href = `https://${document.location.hostname}/${locale}/error/not-found`;  
+      window.location.href = `https://${host}/${locale}/error/not-found`;  
     }
   </script>
   

--- a/404.html
+++ b/404.html
@@ -35,7 +35,7 @@
   <script type="module">
     import { sampleRUM } from '/scripts/lib-franklin.js';
 
-    window.addEventListener('load', () => { 
+    window.addEventListener('load', () => {
       if (document.referrer) {
         const { origin, pathname } = new URL(document.referrer);
         if (origin === window.location.origin) {

--- a/404.html
+++ b/404.html
@@ -3,6 +3,28 @@
 
 <head>
   <title>Page not found</title>
+
+  <script type="text/javascript">
+    // redirect to RM error page when host is a production domain
+    const host = document.location.hostname;
+    if (!host.includes('localhost') && !host.includes('.hlx.')) {
+      // point to locale specific RM error page 
+      const LANG_LOCALE = {
+        es: 'es-ES',
+        en: 'en-US',
+        de: 'de-DE',
+        fr: 'fr-FR',
+        pt: 'pt-PT',
+        ar: 'ar-AE',
+        hi: 'hi-IN',
+        ja: 'ja-JP',
+      };
+      const segments = window.location.pathname.split('/');
+      const locale = segments[1] && LANG_LOCALE[segments[1]] ? LANG_LOCALE[segments[1]] : 'es-ES';
+      window.location.href = `https://${document.location.hostname}/${locale}/error/not-found`;  
+    }
+  </script>
+  
   <script type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
@@ -13,7 +35,7 @@
   <script type="module">
     import { sampleRUM } from '/scripts/lib-franklin.js';
 
-    window.addEventListener('load', () => {
+    window.addEventListener('load', () => { 
       if (document.referrer) {
         const { origin, pathname } = new URL(document.referrer);
         if (origin === window.location.origin) {


### PR DESCRIPTION
- If `localhost ` or `.hlx.` domain, Franklin default 404 page is shown.
- Otherwise redirects to production domain error page , `<locale>/error/not-found`
- Tries to pick locale , defaults to `en-ES` otherwise

Fix #190

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/
- After: https://190-404-redirect--realmadrid--hlxsites.hlx.page/

NOTE: Lighthouse score will not work in this case as its a 404 page causing it to fail. Also the redirect will only trigger when on a live domain.
