### PR TITLE
fix: for tour section page the current selected section 'individual' needs to be tracked as well

### DIFF
--- a/sites/scripts/delayed.js
+++ b/sites/scripts/delayed.js
@@ -41,6 +41,10 @@ function getPageLoadTrackingPayload() {
   const trackingPageName = trackingPathArray.length > 1 ? ['realmadrid', currentSection].concat(trackingPathArray.slice(1))
     : ['realmadrid', currentSection];
 
+  if (currentSection === 'tour' && trackingPageName.length === 2) {
+    trackingPageName.push('individual');
+  }
+
   const webPageDetails = {
     pageName: trackingPageName.join(':'),
     pageTitle: getMetadata('og:title'),


### PR DESCRIPTION
This is the only page where we need to track under page name and page levels, an information that is not present in the page URL - the section selected on that page ('individual').

See conversation with customer: https://adobe-dx-support.slack.com/archives/C04L2G6GF8X/p1688558090628499?thread_ts=1682323232.901519&cid=C04L2G6GF8X

Alternatives:
* take the value from the `keywords` meta tag => not working, because the value would be in the language of the page and we need to track it in the primary language
* take the value from a separate `tour-category` meta tag => adds additional content authoring work and this case only applies to a single page
* take the value from a class of the hero-tour block => less preferable, as it ties the data layer tracking to the block implementation

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
- After: https://fix-tour-category-tracking--realmadrid--hlxsites.hlx.page/sites/tour-bernabeu
