### PR TITLE
add nav to VIP hero image

### DIFF
--- a/sites/blocks/content-header/content-header.js
+++ b/sites/blocks/content-header/content-header.js
@@ -1,14 +1,10 @@
-async function getTitle(path) {
-  const resp = await fetch(`${path}`);
-  if (resp.ok) {
-    const text = await resp.text();
-    return document.createRange().createContextualFragment(text).querySelector('title')?.innerText;
-  }
-  return '';
-}
+import { fetchVIPAreaIndex } from '../../scripts/scripts.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   block.textContent = '';
+  // get the index for this VIP section
+  const index = await fetchVIPAreaIndex();
+
   // if there is an h1 in main text take it as the main title otherwise page title
   const hasH1Title = document.querySelector('main h1:first-child');
   const title = hasH1Title ? (hasH1Title.remove(), hasH1Title.innerText) : document.querySelector('title')?.innerText;
@@ -32,8 +28,8 @@ export default function decorate(block) {
     if (nextSubPath !== curPath) {
       const a = document.createElement('a');
       a.setAttribute('href', nextSubPath);
-      const parentTitle = await getTitle(nextSubPath);
-      if (parentTitle !== '') {
+      const parentTitle = index.find((e) => e.path === nextSubPath)?.title;
+      if (parentTitle !== undefined) {
         a.innerText = parentTitle;
         breadcrumb.append(a);
         breadcrumb.append(' · ');

--- a/sites/blocks/hero/hero.css
+++ b/sites/blocks/hero/hero.css
@@ -55,8 +55,13 @@ main .hero .navigation .parent span.icon {
   transform: rotate(180deg);
 }
 
+main .hero .children {
+  display:flex;
+}
+
 main .hero .navigation .child {
-  display: inline-flex;
+  display:inline-flex;
+  min-width: max-content;
   align-items: center;
   justify-content: flex-start;
   height: 2rem;

--- a/sites/blocks/hero/hero.css
+++ b/sites/blocks/hero/hero.css
@@ -30,42 +30,13 @@ main .hero .navigation {
   flex-grow: 2;
 }
 
-main .hero .navigation .parent {
+main .hero .navigation .parent, main .hero .navigation .child {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
-  height: 2rem;
-  margin:  0;
-  font-size: 0.8125rem;
-  text-decoration: none;
-  text-transform: uppercase;
-  color: var(--background-color);
-  line-height: 1;
-  font-weight: 600;
-  letter-spacing: 0.13px;
-  padding: 0 1rem;
-  box-sizing: border-box;
-  background-color: rgba(0 0 0 / 40%);
-  border-radius: 1rem;
-}
-
-main .hero .navigation .parent span.icon {
-  padding-inline-start: 0.5rem;
-  height: 18px;
-  transform: rotate(180deg);
-}
-
-main .hero .children {
-  display:flex;
-}
-
-main .hero .navigation .child {
-  display:inline-flex;
   min-width: max-content;
-  align-items: center;
   justify-content: flex-start;
   height: 2rem;
-  margin: 1rem 0.5rem;
+  margin: 0.5rem;
   font-size: 0.8125rem;
   text-decoration: none;
   text-transform: uppercase;
@@ -79,9 +50,25 @@ main .hero .navigation .child {
   border-radius: 1rem;
 }
 
-main .hero .navigation .child span.icon {
+main .hero .navigation .parent span.icon {
   padding-inline-start: 0.5rem;
   height: 18px;
+  transform: rotate(180deg);
+}
+
+main .hero .children {
+  display: flex;
+  transition-property: transform;
+  transition-timing-function: ease-out;
+  box-sizing: content-box;
+  overflow: auto;
+  scrollbar-width:none;
+  scroll-behavior: smooth;
+  -ms-overflow-style: none;
+}
+
+main .hero .children::-webkit-scrollbar {
+  display:none;
 }
 
 main .hero-content {

--- a/sites/blocks/hero/hero.css
+++ b/sites/blocks/hero/hero.css
@@ -68,6 +68,7 @@ main .hero .navigation .child {
   margin: 1rem 0.5rem;
   font-size: 0.8125rem;
   text-decoration: none;
+  text-transform: uppercase;
   color: var(--background-color);
   line-height: 1;
   font-weight: 600;

--- a/sites/blocks/hero/hero.css
+++ b/sites/blocks/hero/hero.css
@@ -20,8 +20,62 @@ main .hero {
   margin-top:-64px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content:flex-end;
   color: var(--background-color);
+}
+
+main .hero .navigation {
+  z-index: 3;
+  margin-top:80px;
+  flex-grow: 2;
+}
+
+main .hero .navigation .parent {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 2rem;
+  margin:  0;
+  font-size: 0.8125rem;
+  text-decoration: none;
+  text-transform: uppercase;
+  color: var(--background-color);
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: 0.13px;
+  padding: 0 1rem;
+  box-sizing: border-box;
+  background-color: rgba(0 0 0 / 40%);
+  border-radius: 1rem;
+}
+
+main .hero .navigation .parent span.icon {
+  padding-inline-start: 0.5rem;
+  height: 18px;
+  transform: rotate(180deg);
+}
+
+main .hero .navigation .child {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 2rem;
+  margin: 1rem 0.5rem;
+  font-size: 0.8125rem;
+  text-decoration: none;
+  color: var(--background-color);
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: 0.13px;
+  padding: 0 1rem;
+  box-sizing: border-box;
+  background-color: rgba(100 100 100 / 40%);
+  border-radius: 1rem;
+}
+
+main .hero .navigation .child span.icon {
+  padding-inline-start: 0.5rem;
+  height: 18px;
 }
 
 main .hero-content {

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -36,8 +36,8 @@ async function addNavigation(block) {
   const childrenDiv = document.createElement('div');
   childrenDiv.classList.add('children');
   index.forEach((entry) => {
-    if (entry.path.startsWith(currentPath) && entry.path.split('/').length === childrenDepth && 
-    entry.category !== 'vip-area-detail') {
+    if (entry.path.startsWith(currentPath) && entry.path.split('/').length === childrenDepth
+    && entry.category !== 'vip-area-detail') {
       childrenDiv.append(document.createRange().createContextualFragment(`
       <a href='${entry.path}'class='child'></span>${entry.title}</a>
       `));

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -11,7 +11,7 @@ async function addNavigation(block) {
   const vipRoot = getVIPAreaLangRoot();
   const currentPath = document.location.pathname;
   // no navigation for VIP root page
-  // if (currentPath === vipRoot) return;
+  if (currentPath === vipRoot) return;
 
   // get query index for this language
   const index = await getVIPQueryindex(vipRoot);
@@ -36,9 +36,10 @@ async function addNavigation(block) {
   const childrenDiv = document.createElement('div');
   childrenDiv.classList.add('children');
   index.forEach((entry) => {
-    if (entry.path.startsWith(currentPath) && entry.path.split('/').length === childrenDepth) {
+    if (entry.path.startsWith(currentPath) && entry.path.split('/').length === childrenDepth && 
+    entry.category !== 'vip-area-detail') {
       childrenDiv.append(document.createRange().createContextualFragment(`
-      <a href='${entry.path}'class='child'><span class='icon icon-arrow-right'></span>${entry.title}</a>
+      <a href='${entry.path}'class='child'></span>${entry.title}</a>
       `));
     }
   });

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -11,7 +11,7 @@ async function addNavigation(block) {
   const vipRoot = getVIPAreaLangRoot();
   const currentPath = document.location.pathname;
   // no navigation for VIP root page
-  if (currentPath === vipRoot) return;
+  // if (currentPath === vipRoot) return;
 
   // get query index for this language
   const index = await getVIPQueryindex(vipRoot);

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -10,8 +10,6 @@ async function addNavigation(block) {
   // get language dependent root
   const vipRoot = getVIPAreaLangRoot();
   const currentPath = document.location.pathname;
-  // no navigation for VIP root page
-  // if (currentPath === vipRoot) return;
 
   // get query index for this language
   const index = await getVIPQueryindex(vipRoot);
@@ -25,28 +23,32 @@ async function addNavigation(block) {
   const parentPath = currentPath.substring(0, currentPath.lastIndexOf('/'));
   // get index entry for parent
   const parentIndex = index.find((parentEntry) => parentEntry.path === parentPath);
+  // append parent link to hero navigation
   if (parentIndex) {
     nav.append(document.createRange().createContextualFragment(`
     <a href='${parentPath}'class='parent'><span class='icon icon-arrow-right'></span>${parentIndex.title}</a>
     `));
   }
 
-  // add direct children
+  // check for children
   const childrenDepth = currentPath.split('/').length + 1;
-  const childrenDiv = document.createElement('div');
-  childrenDiv.classList.add('children');
-  index.forEach((entry) => {
-    if (entry.path.startsWith(currentPath) && entry.path.split('/').length === childrenDepth
-    && entry.category !== 'vip-area-detail') {
+  const childrenIndex = index.filter((entry) => entry.path.startsWith(currentPath)
+    // ignore vip area detail pages
+    && entry.path.split('/').length === childrenDepth && entry.category !== 'vip-area-detail');
+
+  if (childrenIndex) {
+    // create children list root element
+    const childrenDiv = document.createElement('div');
+    childrenDiv.classList.add('children');
+    // add children
+    childrenIndex.forEach((entry) => {
       childrenDiv.append(document.createRange().createContextualFragment(`
-      <a href='${entry.path}'class='child'></span>${entry.title}</a>
-      `));
-    }
-  });
-  if (childrenDiv.hasChildNodes()) {
+      <a href='${entry.path}'class='child'>${entry.title}</a>`));
+    });
+    // add children list to hero navittion
     nav.append(childrenDiv);
   }
-
+  // decorate the arrow icon for the parent link
   decorateIcons(nav);
   // append navigation block
   block.prepend(nav);

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -1,18 +1,11 @@
 import { decorateIcons, createOptimizedPicture } from '../../scripts/lib-franklin.js';
-import { getVIPAreaLangRoot } from '../../scripts/scripts.js';
-
-async function getVIPQueryindex(vipRoot) {
-  const resp = await fetch(`${vipRoot}/query-index.json`);
-  return resp.ok ? (await resp.json()).data : null;
-}
+import { fetchVIPAreaIndex } from '../../scripts/scripts.js';
 
 async function addNavigation(block) {
-  // get language dependent root
-  const vipRoot = getVIPAreaLangRoot();
   const currentPath = document.location.pathname;
 
   // get query index for this language
-  const index = await getVIPQueryindex(vipRoot);
+  const index = await fetchVIPAreaIndex();
   if (index === null) return;
 
   // nav container div
@@ -34,7 +27,7 @@ async function addNavigation(block) {
   const childrenDepth = currentPath.split('/').length + 1;
   const childrenIndex = index.filter((entry) => entry.path.startsWith(currentPath)
     // ignore vip area detail pages
-    && entry.path.split('/').length === childrenDepth && entry.category !== 'vip-area-detail');
+    && entry.path.split('/').length === childrenDepth && !entry.category.startsWith('vip-area-detail'));
 
   if (childrenIndex) {
     // create children list root element

--- a/sites/blocks/vip-areas/vip-areas.js
+++ b/sites/blocks/vip-areas/vip-areas.js
@@ -1,14 +1,12 @@
 import { createOptimizedPicture, readBlockConfig } from '../../scripts/lib-franklin.js';
-import { getVipAreaIndexPath } from '../../scripts/scripts.js';
+import { fetchVIPAreaIndex } from '../../scripts/scripts.js';
 
 const AREAS_VIP_DETAIL = 'vip-area-detail';
 
-async function fetchVIPAreas(category) {
+async function getVIPAreasByCategory(category) {
   try {
-    const vipAreaIndexPath = getVipAreaIndexPath(new URL(window.location));
-    const resp = await fetch(vipAreaIndexPath);
-    const json = await resp.json();
-    return json.data.filter((area) => area.category === (category || AREAS_VIP_DETAIL));
+    return (await fetchVIPAreaIndex())
+      .filter((area) => area.category === (category || AREAS_VIP_DETAIL));
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(`unable to fetch vip areas ${e}`);
@@ -46,10 +44,10 @@ function areaElement(area) {
  */
 export default async function decorate(block) {
   const { category } = readBlockConfig(block);
-  const vipareas = await fetchVIPAreas(category);
+  const vipareas = await getVIPAreasByCategory(category);
   const ul = document.createElement('ul');
 
-  vipareas.map(areaElement)
-    .forEach((li) => ul.appendChild(li));
+  vipareas.map(areaElement).forEach((li) => ul.appendChild(li));
+  block.textContent = '';
   block.append(ul);
 }

--- a/sites/scripts/scripts.js
+++ b/sites/scripts/scripts.js
@@ -237,6 +237,40 @@ export async function fetchTours() {
   return null;
 }
 
+const VIP_AREA_INDEX = '/query-index.json';
+
+/**
+ * loads the index if we are on a VIP area page.
+ */
+export async function fetchVIPAreaIndex() {
+  const vipRoot = getVIPAreaLangRoot();
+  // if we are on a vip area page
+  if (window.location.pathname.startsWith(vipRoot)) {
+    // return query index for this language
+    if (window.vipIndex?.data) {
+      return window.vipIndex.data;
+    }
+
+    // make sure global storage location exists
+    window.vipIndex = window.vipIndex || {};
+
+    // define promise function
+    const loadVIPAreaIndex = async () => {
+      const resp = await fetch(`${vipRoot}${VIP_AREA_INDEX}`);
+      window.vipIndex.data = (await resp.json()).data;
+      return window.vipIndex.data;
+    };
+
+    // start download
+    if (!window.vipIndex.promise) {
+      // create promise
+      window.vipIndex.promise = loadVIPAreaIndex();
+    }
+    return window.vipIndex.promise;
+  }
+  return null;
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
@@ -320,7 +354,6 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
-const VIP_AREA_INDEX = '/query-index.json';
 export const LANG_LOCALE = {
   es: 'es-ES',
   en: 'en-US',
@@ -352,11 +385,6 @@ export async function fetchNavigationConfig() {
     console.error(error);
   }
   return navigationConfig;
-}
-
-export function getVipAreaIndexPath(url) {
-  language = getLanguage();
-  return `${url.origin}${VIP_AREA_LANGUAGE_HOME_PATH[language]}${VIP_AREA_INDEX}`;
 }
 
 export async function fetchLanguagePlaceholders() {


### PR DESCRIPTION
adds navigation to the hero block in the VIP section:
- all pages below VIP root get a link back to parent page
- if page has direct children they get listed unless the page category starts with `vip-area-detail`
- it loads the query index in non-blocking way for VIP Area pages once and stores it in `window.vipIndex.data`
- the index is used by the hero block to add the navigation
- by vip-areas block to get all detail pages for the selected category
- by the faq content-header block to render the breadcrumb 

Fix #200

Test URLs:
- Before:
https://main--realmadrid--hlxsites.hlx.live/sites/area-vip
https://main--realmadrid--hlxsites.hlx.live/sites/area-vip/faq
https://main--realmadrid--hlxsites.hlx.live/sites/en/vip-area/matchday-hospitality
https://main--realmadrid--hlxsites.hlx.live/sites/area-vip/partido-vip/silver-club-130-132
- After: 
https://200-vip-navigation--realmadrid--hlxsites.hlx.live/sites/area-vip
https://200-vip-navigation--realmadrid--hlxsites.hlx.live/sites/area-vip/faq
https://200-vip-navigation--realmadrid--hlxsites.hlx.live/sites/en/vip-area/matchday-hospitality
https://200-vip-navigation--realmadrid--hlxsites.hlx.live/sites/area-vip/partido-vip/silver-club-130-132