### PR TITLE
148 only load mobile/desktop hero video as needed.

### DIFF
--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -16,12 +16,25 @@ function createVideo(block) {
     }
     return video;
   });
-  if (videos.length === 1) { // if there is only 1 video show it on mobile as well
-    videos[0].setAttribute('data-screen-mobile', '');
-  }
+
   const div = document.createElement('div');
   div.classList.add('video');
-  div.append(...videos);
+
+  if (videos.length === 1) {
+    // if there is only 1 video show it on mobile as well
+    videos[0].setAttribute('data-screen-mobile', '');
+  } else {
+    // if there are 2 videos, create a mediaquery
+    const mq = window.matchMedia('(min-width:990px)');
+    // add an event listener to the media query
+    mq.addEventListener('change', (e) => {
+      // either add mobile or desktop video element
+      div.append(e.target.matches ? videos[0] : videos[1]);
+    });
+    // trigger it to set the right video on load
+    mq.dispatchEvent(new Event('change'));
+  }
+
   return div;
 }
 

--- a/sites/blocks/hero/hero.js
+++ b/sites/blocks/hero/hero.js
@@ -3,6 +3,7 @@ import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 function createVideo(block) {
   const anchors = [...block.querySelectorAll('a[href$=".mp4"]')];
   const screens = ['desktop', 'mobile'];
+  const src = {};
   const videos = anchors.map((a, i) => {
     const video = document.createElement('video');
     video.setAttribute('loop', '');
@@ -10,9 +11,9 @@ function createVideo(block) {
     video.muted = true;
     video.setAttribute('playsInline', '');
     video.setAttribute('autoplay', '');
-    video.innerHTML = `<source src="${a.href}" type="video/mp4" />`;
     if (screens[i]) {
       video.setAttribute(`data-screen-${screens[i]}`, '');
+      src[screens[i]] = `<source src="${a.href}" type="video/mp4" />`;
     }
     return video;
   });
@@ -29,12 +30,13 @@ function createVideo(block) {
     // add an event listener to the media query
     mq.addEventListener('change', (e) => {
       // either add mobile or desktop video element
-      div.append(e.target.matches ? videos[0] : videos[1]);
+      // eslint-disable-next-line no-unused-expressions
+      e.target.matches ? videos[0].innerHTML = src.desktop : videos[1].innerHTML = src.mobile;
     });
     // trigger it to set the right video on load
     mq.dispatchEvent(new Event('change'));
   }
-
+  div.append(...videos);
   return div;
 }
 


### PR DESCRIPTION
- initially it only adds the `source` element for the proper video size, `mobile `or `desktop`
- if media breakpoint is hit  ( `min-width:990px` ) , it adds the other `source` tag

NOTE: open developer console, go to `network `tab, filter by `media`, resize window to see when vidoes get loaded.

Fix #148

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.live/sites/area-vip
- After: https://148-video--realmadrid--hlxsites.hlx.live/sites/area-vip
