### PR TITLE
212 Vertical scroll for pop up menu when width > 1056px 

### DIFF
--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -137,7 +137,7 @@ a.top-menu-mobile-item {
   position: absolute;
   left: 350px;
   width: 260px;
-  top: -5px;
+  top: 0;
   padding-top: 43px;
   padding-inline-start: 59px;
   padding-inline-end: 40px;

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -142,7 +142,7 @@ a.top-menu-mobile-item {
   padding-inline-start: 59px;
   padding-inline-end: 40px;
   overflow-y: scroll;
-  height: calc(100% - 3em);
+  height: calc(100% - 6em);
 }
 
 .sub-popup-menu-area:lang(ar) {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -19,6 +19,21 @@
   height: calc(100% - 3em);
 }
 
+.scrollable-popup-menu-area::-webkit-scrollbar {
+  width: .25rem;
+  height: .25rem;
+}
+
+.scrollable-popup-menu-area::-webkit-scrollbar-thumb {
+  background-color: var(--rm-color-grayscale-light, #c7ccd6);
+  border: 3px solid transparent;
+  border-radius: 1.25rem;
+}
+
+.scrollable-popup-menu-area::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 .popup-menu-area:lang(ar) {
   right: 0;
   left: unset;

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -142,7 +142,7 @@ a.top-menu-mobile-item {
   padding-inline-start: 59px;
   padding-inline-end: 40px;
   overflow-y: scroll;
-  height: calc(100% - 6em);
+  height: calc(100% - 5.375em);
 }
 
 .sub-popup-menu-area:lang(ar) {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -136,7 +136,7 @@ a.top-menu-mobile-item {
 .sub-popup-menu-area {
   position: absolute;
   left: 350px;
-  width: 300px;
+  width: 260px;
   top: -5px;
   padding-top: 43px;
   padding-inline-start: 59px;

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -15,12 +15,8 @@
 }
 
 .scrollable-popup-menu-area {
-  overflow-y: hidden;
-  height: calc(100% - 3em);
-}
-
-.scrollable-popup-menu-area:hover {
   overflow-y: auto;
+  height: calc(100% - 3em);
 }
 
 .sub-popup-menu-area::-webkit-scrollbar,  .scrollable-popup-menu-area::-webkit-scrollbar {
@@ -160,12 +156,8 @@ a.top-menu-mobile-item {
   padding-top: 43px;
   padding-inline-start: 59px;
   padding-inline-end: 40px;
-  overflow-y: hidden;
-  height: calc(100% - 5.375em);
-}
-
-.sub-popup-menu-area:hover {
   overflow-y: auto;
+  height: calc(100% - 5.375em);
 }
 
 .sub-popup-menu-area:lang(ar) {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -14,6 +14,11 @@
   transition: 0.5s ease-out all;
 }
 
+.scrollable-popup-menu-area {
+  overflow-y: scroll;
+  height: calc(100% - 3em);
+}
+
 .popup-menu-area:lang(ar) {
   right: 0;
   left: unset;
@@ -229,11 +234,6 @@ a.top-menu-mobile-item {
   .popup-menu:lang(ar) {
     right: -300px;
     left: unset;
-  }
-
-  .scrollable-popup-menu-area {
-    overflow-y: scroll;
-    height: calc(100% - 3em);
   }
 
   .top-menu-mobile {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -15,7 +15,7 @@
 }
 
 .scrollable-popup-menu-area {
-  overflow-y: scroll;
+  overflow-y: auto;
   height: calc(100% - 3em);
 }
 
@@ -141,7 +141,7 @@ a.top-menu-mobile-item {
   padding-top: 43px;
   padding-inline-start: 59px;
   padding-inline-end: 40px;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: calc(100% - 5.375em);
 }
 

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -15,8 +15,12 @@
 }
 
 .scrollable-popup-menu-area {
-  overflow-y: auto;
+  overflow-y: hidden;
   height: calc(100% - 3em);
+}
+
+.scrollable-popup-menu-area:hover {
+  overflow-y: auto;
 }
 
 .sub-popup-menu-area::-webkit-scrollbar,  .scrollable-popup-menu-area::-webkit-scrollbar {
@@ -156,8 +160,12 @@ a.top-menu-mobile-item {
   padding-top: 43px;
   padding-inline-start: 59px;
   padding-inline-end: 40px;
-  overflow-y: auto;
+  overflow-y: hidden;
   height: calc(100% - 5.375em);
+}
+
+.sub-popup-menu-area:hover {
+  overflow-y: auto;
 }
 
 .sub-popup-menu-area:lang(ar) {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -141,6 +141,8 @@ a.top-menu-mobile-item {
   padding-top: 43px;
   padding-inline-start: 59px;
   padding-inline-end: 40px;
+  overflow-y: scroll;
+  height: calc(100% - 3em);
 }
 
 .sub-popup-menu-area:lang(ar) {
@@ -207,6 +209,8 @@ a.top-menu-mobile-item {
 .language-popup-menu-area {
   border-top: 1px solid #E1E5E9;
   padding-inline-start: 40px;
+  background-color: white;
+  position:relative;
 }
 
 @media screen and (max-width: 1160px) {

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -16,6 +16,7 @@
 
 .scrollable-popup-menu-area {
   overflow-y: auto;
+  overflow-x:hidden;
   height: calc(100% - 3em);
 }
 

--- a/sites/blocks/header/popupMenu.css
+++ b/sites/blocks/header/popupMenu.css
@@ -19,18 +19,18 @@
   height: calc(100% - 3em);
 }
 
-.scrollable-popup-menu-area::-webkit-scrollbar {
+.sub-popup-menu-area::-webkit-scrollbar,  .scrollable-popup-menu-area::-webkit-scrollbar {
   width: .25rem;
   height: .25rem;
 }
 
-.scrollable-popup-menu-area::-webkit-scrollbar-thumb {
+.sub-popup-menu-area::-webkit-scrollbar-thumb,  .scrollable-popup-menu-area::-webkit-scrollbar-thumb {
   background-color: var(--rm-color-grayscale-light, #c7ccd6);
   border: 3px solid transparent;
   border-radius: 1.25rem;
 }
 
-.scrollable-popup-menu-area::-webkit-scrollbar-track {
+.sub-popup-menu-area::-webkit-scrollbar-track,  .scrollable-popup-menu-area::-webkit-scrollbar-track {
   background: transparent;
 }
 


### PR DESCRIPTION
- adds vertical scrolling for the pop up menu, when the width is > 1056px and the browser window height is to small.
- It adds vertical scrolling to the main menu and the sub menu
- the image that appears in a 3rd column for width > 1160px is not scrolling

![image](https://github.com/hlxsites/realmadrid/assets/37147400/70fd1e19-932e-416b-8510-b77c054a48c9)


Fix #212

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/area-vip
- After: https://212-popupmenu-scroll--realmadrid--hlxsites.hlx.page/sites/area-vip

To Test:
- Open Developer console
- make height small
- open pop up menu, go to 'Club' which has a large sub menu
- change width to see the different menu colums appear with the scrollbar
- scroll main / sub menu 
- resize height to make scrollbars disappear
