### PR TITLE
feat: track pageLoadType in the data layer always set to sequential

### DIFF
--- a/sites/scripts/delayed.js
+++ b/sites/scripts/delayed.js
@@ -58,6 +58,7 @@ function getPageLoadTrackingPayload() {
     previousPageURL: document.referrer,
     pageLang: currentLanguage,
     country: currentLanguage,
+    pageLoadType: 'sequential',
     cms: 'aem_franklin',
   };
 


### PR DESCRIPTION
Per customer request: https://adobe-dx-support.slack.com/archives/C04L2G6GF8X/p1689926189001269?thread_ts=1682323232.901519&cid=C04L2G6GF8X

Test URLs:
- Before: https://main--realmadrid--hlxsites.hlx.page/sites/area-vip
- After: https://dl-page-load-type--realmadrid--hlxsites.hlx.page/sites/area-vip
